### PR TITLE
Fixes detection of InOut-dependences in loop bodies for single statements

### DIFF
--- a/graph_analyzer/pattern_detectors/pipeline_detector.py
+++ b/graph_analyzer/pattern_detectors/pipeline_detector.py
@@ -79,7 +79,7 @@ class PipelineInfo(PatternInfo):
         for n in get_subtree_of_type(self._pet, node, 'cu'):
             raw.extend(e for e in n.out_edges() if self._pet.graph.ep.dtype[e] == 'RAW')
 
-        nodes_before = []
+        nodes_before = [node]
         for i in range(self._stages.index(node)):
             nodes_before.extend(get_subtree_of_type(self._pet, self._stages[i], 'cu'))
 
@@ -90,7 +90,7 @@ class PipelineInfo(PatternInfo):
         for n in get_subtree_of_type(self._pet, node, 'cu'):
             raw.extend(e for e in n.in_edges() if self._pet.graph.ep.dtype[e] == 'RAW')
 
-        nodes_after = []
+        nodes_after = [node]
         for i in range(self._stages.index(node) + 1, len(self._stages)):
             nodes_after.extend(get_subtree_of_type(self._pet, self._stages[i], 'cu'))
 


### PR DESCRIPTION
Example:
    int d = 20,a=22, b=44,c=90;
    for (i=0; i<100; i++) {
        a = foo(i, d);
        b = bar(a, d);
        c = delta(b, c);
    }

prior: c was detected as private
now: c detected as InOut-dependency

Effect: incoming and outgoing (cyclic) dependencies to own node are now included in output of __in_dep and __out_dep
[test.c.txt](https://github.com/discopop-project/discopop/files/4609873/test.c.txt)

