### PR TITLE
Add basic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+# This file is part of the DiscoPoP software (http://www.discopop.tu-darmstadt.de)
+#
+# Copyright (c) 2020, Technische Universitaet Darmstadt, Germany
+#
+# This software may be modified and distributed under the terms of
+# the 3-Clause BSD License.  See the LICENSE file in the package base
+# directory for details.
+
+name: "DiscoPoP CI"
+on: [push, pull_request]
+
+jobs:
+
+  graph_analyzer:
+    name: "Graph Analyzer"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v2
+      - name: "Build Image with Dependencies"
+        run: docker build -f .github/workflows/graph_analyzer/Dockerfile . --tag graph_analyzer
+      - name: "Run unit_tests.py"
+        run: docker run --mount type=bind,src=`pwd`,dst=/discopop --workdir=/discopop/graph_analyzer graph_analyzer python unit_tests.py
+
+  discopop_profiler:
+    name: "Profiler"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v2
+      - name: "Build DiscoPoP Profiler"
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Debug ..
+          make -j3
+      - name: "Run DiscoPoP Profiler on test/ Targets"
+        run: .github/workflows/discopop_profiler/test.sh

--- a/.github/workflows/discopop_profiler/test.sh
+++ b/.github/workflows/discopop_profiler/test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# This file is part of the DiscoPoP software (http://www.discopop.tu-darmstadt.de)
+#
+# Copyright (c) 2020, Technische Universitaet Darmstadt, Germany
+#
+# This software may be modified and distributed under the terms of
+# the 3-Clause BSD License.  See the LICENSE file in the package base
+# directory for details.
+
+cd "$(dirname "$0")/../../.." || exit 1
+
+DISCOPOP_SRC=$(pwd)
+DISCOPOP_INSTALL="$(pwd)/build"
+CXX=clang++-8
+
+tests="dependence reduction"  # TODO: "cu" yet missing because it fails
+
+function test_cu {
+  # CU Generation
+  ${CXX} -g -O0 -fno-discard-value-names -Xclang -load -Xclang "${DISCOPOP_INSTALL}"/libi/LLVMCUGeneration.so -mllvm -fm-path -mllvm ./FileMapping.txt -c "$1" || return 1
+}
+
+function test_dependence {
+  # Dependence Profiling
+  ${CXX} -g -O0 -fno-discard-value-names -Xclang -load -Xclang "${DISCOPOP_INSTALL}"/libi/LLVMDPInstrumentation.so -mllvm -fm-path -mllvm ./FileMapping.txt -c "$1" -o out.o || return 1
+  ${CXX} out.o -L"${DISCOPOP_INSTALL}"/rtlib -lDiscoPoP_RT -lpthread || return 1
+  ./a.out || return 1
+}
+
+function test_reduction {
+  # Identifying Reduction Operations
+  ${CXX} -g -O0 -fno-discard-value-names -Xclang -load -Xclang "${DISCOPOP_INSTALL}"/libi/LLVMDPReduction.so -mllvm -fm-path -mllvm ./FileMapping.txt -c "$1" -o out.o || return 1
+  ${CXX} out.o -L"${DISCOPOP_INSTALL}"/rtlib -lDiscoPoP_RT -lpthread || return 1
+  ./a.out || return 1
+}
+
+exit_code=0
+for target in ./test/*/; do
+  pushd $target
+  ${DISCOPOP_SRC}/scripts/dp-fmap
+  for test in ${tests}; do
+    echo "###"
+    echo "### ${target} ${test}"
+    echo "###"
+    if ! test_$test "$(ls ./*.c ./*.cpp 2>/dev/null)"; then
+      exit_code=1
+      echo -e "\e[31m### ${target} ${test} failed.\e[0m"
+    fi
+  done
+  popd
+done
+
+exit $exit_code

--- a/.github/workflows/graph_analyzer/Dockerfile
+++ b/.github/workflows/graph_analyzer/Dockerfile
@@ -1,0 +1,14 @@
+# This file is part of the DiscoPoP software (http://www.discopop.tu-darmstadt.de)
+#
+# Copyright (c) 2020, Technische Universitaet Darmstadt, Germany
+#
+# This software may be modified and distributed under the terms of
+# the 3-Clause BSD License.  See the LICENSE file in the package base
+# directory for details.
+
+# Dockerfile for an image containing the dependencies of graph_analyzer
+
+FROM tiagopeixoto/graph-tool
+RUN pacman --noconfirm -S python-pip
+COPY graph_analyzer/requirements.txt /requirements.txt
+RUN pip install -r /requirements.txt


### PR DESCRIPTION
This adds a GitHub Actions workflow consisting of two jobs, one of which runs the end-to-end tests of the Graph Analyzer which we have in `graph_analyzer/unit_tests.py`, and the other one compiles the profiler and runs DPInstrumentation and DPReduction on the examples in `test/`.

CUGeneration is left out since it currently fails (#26).

It does not yet run any linting or static type checking on the Python code, since Pylint and MyPy yield many errors at the moment, which I suggest to address separately.