### PR TITLE
Script to help creating a new DiscoPoP version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,9 @@ jobs:
   publish:
     name: "Publish Package"
     runs-on: ubuntu-latest
-    if: github.actor != 'github-actions'
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: "Setup Python"
         uses: actions/setup-python@v2
         with:
@@ -25,36 +22,9 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
         shell: bash
-      - name: "Create Version Files and Move Annotated Tag"
-        env:
-          GITHUB_REF: ${{ github.ref }}
-          VERSION: ${{ steps.get_version.outputs.VERSION }}
-        shell: bash
-        run: |
-          git fetch --tags --force origin ${GITHUB_REF}
-          git config user.name "$(git for-each-ref --format='%(taggername)' ${GITHUB_REF})"
-          git config user.email $(git for-each-ref --format='%(taggeremail)' ${GITHUB_REF})
-          git checkout -b release/v${VERSION} ${GITHUB_REF}
-          echo "${VERSION}" > VERSION
-          echo "__version__ = \"${VERSION}\"" > discopop_explorer/_version.py
-          echo "__version__ = \"${VERSION}\"" > discopop_profiler/_version.py
-          git add VERSION discopop_explorer/_version.py discopop_profiler/_version.py
-          git commit -m "Release of Version ${VERSION}"
-          git tag -a -f -m "Version ${VERSION}" v${VERSION}
-          git push --set-upstream origin release/v${VERSION}
-          git push --tags --force
-      - name: "Create pull request"
-        uses: repo-sync/pull-request@v2
-        with:
-          source_branch: release/v${{ steps.get_version.outputs.VERSION }}
-          destination_branch: master
-          pr_title: "Release of version ${{ steps.get_version.outputs.VERSION }}"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: "Generate Python Package"
         run: python setup.py sdist
       - name: "Create Draft Release on GitHub"
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +33,6 @@ jobs:
           release_name: Version ${{ steps.get_version.outputs.VERSION }}
           draft: true
       - name: "Publish Distribution to PyPI"
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.pypi_password }}

--- a/scripts/dev/create-release.sh
+++ b/scripts/dev/create-release.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# Script to help creating a new DiscoPoP Version.
+#
+# This script creates
+# - a commit "Release of Version ${VERSION}" in release/v${VERSION} to update the
+#   version files, and
+# - a tag "v${VERSION}" pointing to the new commit.
+# After that, it prints the steps that are required manually for finalizing the
+# release creation.
+#
+# Usage:
+#   scripts/dev/create-release.sh <version>
+# where <version> is a valid version identifier, such as "1.2.0".
+
+function error {
+  echo "$*" > /dev/stderr
+  exit 1
+}
+
+VERSION=$1
+[ -z "$VERSION" ] && error "Usage: $0 <version>"
+
+# Regular expression for a version number, copied from PEP440
+VERSION_REGEX='^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$'
+echo "$VERSION" | grep -qEe "$VERSION_REGEX" || \
+    error "\"$VERSION\" is not a valid version number."
+
+cd "$(dirname "$0")/../.." || error "cd into source root failed."
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+[ "$CURRENT_BRANCH" != "master" ] && [ "$CURRENT_BRANCH" != "develop" ] && \
+    error "You are not in master or develop branch."
+
+[ -z "$(git status --short)" ] || error "Working tree is not clean."
+
+git checkout -b "release/v${VERSION}" || error "Failed."
+echo "${VERSION}" > VERSION
+echo "__version__ = \"${VERSION}\"" > discopop_explorer/_version.py
+echo "__version__ = \"${VERSION}\"" > discopop_profiler/_version.py
+git add VERSION discopop_explorer/_version.py discopop_profiler/_version.py || \
+    error "Failed."
+git commit -m "Release of Version ${VERSION}" || error "Failed."
+git tag -a -m "Version ${VERSION}" "v${VERSION}" || error "Failed."
+
+cat << EOF
+
+
+Created
+ - a commit "Release of Version ${VERSION}" in release/v${VERSION} to update the
+   version files, and
+ - a tag "v${VERSION}" pointing to the new commit.
+
+To finalize releasing, do the following five steps manually:
+ 1. git push --set-upstream origin release/v${VERSION}
+ 2. Create a Pull Request for the newly pushed branch release/v${VERSION}
+ 3. Merge the branch release/v${VERSION} into ${CURRENT_BRANCH} without altering the
+    commit hash
+ 4. git push --tags
+ The CI will then automatically publish the release to PyPI and create a Draft Release
+ on GitHub
+ 5. Go to GitHub and remove the "Draft" flag of the new release
+EOF


### PR DESCRIPTION
Until now, our "Publish Package" CI action did all the necessary steps for creating a new release when a new tag is pushed. This included creating a commit to update the version files, moving the tag to the new commit and then force-pushing. This interfered with the branch protection in our repository.

This pull request changes the workflow to create a new release by moving some of the steps to a shell script in order to not interfere with how we review pushes to protected branches.

The here-added script creates

- a commit "Release of Version ${VERSION}" in release/v${VERSION} to update the version files, and
- a tag "v${VERSION}" pointing to the new commit.

After that, it prints the steps that are required manually for finalizing the release creation.
