### PR TITLE
feature: display details of suggestions in collapsible elements

### DIFF
--- a/discopop_wizard/classes/Suggestions.py
+++ b/discopop_wizard/classes/Suggestions.py
@@ -7,6 +7,7 @@
 # directory for details.
 
 import os
+from typing import List
 
 import pytermgui as ptg
 
@@ -19,6 +20,20 @@ class Suggestion(object):
         suggestion = suggestion.replace("\t", "    ")
         self.suggestion = suggestion
         self.id = id
+
+    def get_as_collapsible(self, manager: ptg.WindowManager, wizard, execution_configuration,
+                           all_collapsibles: List[ptg.Collapsible]):
+        collapsible = ptg.Collapsible(self.suggestion.split("\n")[0], parent_align=ptg.enums.HorizontalAlignment.LEFT)
+        collapsible.lazy_add(ptg.Label(self.suggestion,
+                                        parent_align=ptg.enums.HorizontalAlignment.LEFT,
+                                        ))
+        collapsible.lazy_add(ptg.Button("Show",
+                                        parent_align=ptg.enums.HorizontalAlignment.LEFT,
+                                        onclick=lambda *_: self.__show_code_section(manager, wizard, execution_configuration),
+                                        ))
+        collapsible.lazy_add(ptg.Label(""))
+        all_collapsibles.append(collapsible)
+        return collapsible
 
     def get_as_button(self, manager: ptg.WindowManager, wizard, execution_configuration):
         return ptg.Button(label=self.suggestion.split("\n")[0],
@@ -33,7 +48,7 @@ class Suggestion(object):
     def __show_details_section(self, manager: ptg.WindowManager, wizard):
         # close window
         for slot in manager.layout.slots:
-            if slot.name == "body_1":
+            if slot.name == "body_2":
                 slot.content.close()
 
         # create new details window
@@ -44,13 +59,13 @@ class Suggestion(object):
             .set_title("[210 bold]Details")
         )
         details_window.overflow = ptg.Overflow.SCROLL
-        manager.add(details_window, assign="body_1")
+        manager.add(details_window, assign="body_2")
 
 
     def __show_code_section(self, manager: ptg.WindowManager, wizard, execution_configuration):
         # close window
         for slot in manager.layout.slots:
-            if slot.name == "body_2":
+            if slot.name == "body_1":
                 slot.content.close()
 
         content = ptg.Container()
@@ -98,5 +113,5 @@ class Suggestion(object):
         code_window._max_scroll = file_length  # required to allow scrolling, since window only contains one element
         code_window.scroll(start_line)
 
-        manager.add(code_window, assign="body_2")
+        manager.add(code_window, assign="body_1")
 

--- a/discopop_wizard/screens/suggestions/overview.py
+++ b/discopop_wizard/screens/suggestions/overview.py
@@ -53,11 +53,7 @@ def push_suggestion_overview_screen(manager: ptg.WindowManager, config_dir: str,
     )
     collabsible_patterns.overflow = ptg.Overflow.SCROLL;
 
-
-#    buttons = (ptg.Window(
-#        ["Save", lambda *_: save_configuration(manager, body, config_dir, wizard)],
-#    ))
-    wizard.show_body_windows(manager, [(collabsible_patterns, 0.2), (details_section, 0.2), (code_section, 0.55)])
+    wizard.show_body_windows(manager, [(collabsible_patterns, 0.4), (code_section, 0.55)])
 
 def get_suggestion_view(manager: ptg.WindowManager, suggestions_path: str, wizard, exec_config_obj) -> ptg.Container:
     container = ptg.Container()
@@ -78,8 +74,11 @@ def get_suggestion_view(manager: ptg.WindowManager, suggestions_path: str, wizar
     for idx, suggestion in enumerate(suggestions):
         suggestion_objects.append(Suggestion(idx, suggestion))
 
+
+    all_collapsibles: List[ptg.Collapsible] = []
     for suggestion in suggestion_objects:
-        container.lazy_add(suggestion.get_as_button(manager, wizard, exec_config_obj))
+        #container.lazy_add(suggestion.get_as_button(manager, wizard, exec_config_obj))
+        container.lazy_add(suggestion.get_as_collapsible(manager, wizard, exec_config_obj, all_collapsibles))
     return container
 
 


### PR DESCRIPTION
Removes the `details` window from the `suggestions` screen.
Details are moved into collapsible containers.