### PR TITLE
Wizard: Save configuration to JSON and cleanup help strings

### DIFF
--- a/discopop_explorer/__main__.py
+++ b/discopop_explorer/__main__.py
@@ -15,24 +15,24 @@ Usage:
 [--dp-build-path=<dpbuildpath>] [--generate-data-cu-inst <outputdir>]
 
 OPTIONAL ARGUMENTS:
-*    --path=<dir>               Directory with input data [default: ./]
-*    --cu-xml=<file>            CU node xml file [default: Data.xml]
-*    --dep-file=<file>        Dependencies text file [default: dp_run_dep.txt]
-*    --loop-counter=<file>  Loop counter data [default: loop_counter_output.txt]
-*    --reduction=<file>     Reduction variables file [default: reduction.txt]
-*    --fmap=<file>               File mapping [default: FileMapping.txt]
-*    --json=<file>           Json output
-*    --plugins=<string>           Plugins to execute
-*    --task-pattern              Enables the task parallelism pattern identification.
+    --path=<dir>               Directory with input data [default: ./]
+    --cu-xml=<file>            CU node xml file [default: Data.xml]
+    --dep-file=<file>        Dependencies text file [default: dp_run_dep.txt]
+    --loop-counter=<file>  Loop counter data [default: loop_counter_output.txt]
+    --reduction=<file>     Reduction variables file [default: reduction.txt]
+    --fmap=<file>               File mapping [default: FileMapping.txt]
+    --json=<file>           Json output
+    --plugins=<string>           Plugins to execute
+    --task-pattern              Enables the task parallelism pattern identification.
                                 Requires --cu-inst-res and --llvm-cxxfilt-path to be set.
-*    --cu-inst-res=<file>   CU instantiation result file.
-*    --llvm-cxxfilt-path=<file> Path to llvm-cxxfilt executable. Required for task pattern detector
+    --cu-inst-res=<file>   CU instantiation result file.
+    --llvm-cxxfilt-path=<file> Path to llvm-cxxfilt executable. Required for task pattern detector
                                 if non-standard path should be used.
-*    --dp-build-path=<dir>           Path to DiscoPoP build folder [default: discopop/build]
-*    --generate-data-cu-inst=<dir>     Generates Data_CUInst.txt file and stores it in the given directory.
+    --dp-build-path=<dir>           Path to DiscoPoP build folder [default: discopop/build]
+    --generate-data-cu-inst=<dir>     Generates Data_CUInst.txt file and stores it in the given directory.
                                             Stops the regular execution of the discopop_explorer.
                                             Requires --cu-xml, --dep-file, --loop-counter, --reduction.
-*    -h --help                   Show this screen
+    -h --help                   Show this screen
 """
 
 import json

--- a/discopop_explorer/__main__.py
+++ b/discopop_explorer/__main__.py
@@ -14,25 +14,25 @@ Usage:
 [--task-pattern] [--cu-inst-res <cuinstres>] [--llvm-cxxfilt-path <cxxfp>] \
 [--dp-build-path=<dpbuildpath>] [--generate-data-cu-inst <outputdir>]
 
-Options:
-    --path=<path>               Directory with input data [default: ./]
-    --cu-xml=<cuxml>            CU node xml file [default: Data.xml]
-    --dep-file=<depfile>        Dependencies text file [default: dp_run_dep.txt]
-    --loop-counter=<loopcount>  Loop counter data [default: loop_counter_output.txt]
-    --reduction=<reduction>     Reduction variables file [default: reduction.txt]
-    --fmap=<fmap>               File mapping [default: FileMapping.txt]
-    --json=<json_out>           Json output
-    --plugins=<plugs>           Plugins to execute
-    --task-pattern              Enables the task parallelism pattern identification.
+OPTIONAL ARGUMENTS:
+*    --path=<dir>               Directory with input data [default: ./]
+*    --cu-xml=<file>            CU node xml file [default: Data.xml]
+*    --dep-file=<file>        Dependencies text file [default: dp_run_dep.txt]
+*    --loop-counter=<file>  Loop counter data [default: loop_counter_output.txt]
+*    --reduction=<file>     Reduction variables file [default: reduction.txt]
+*    --fmap=<file>               File mapping [default: FileMapping.txt]
+*    --json=<file>           Json output
+*    --plugins=<string>           Plugins to execute
+*    --task-pattern              Enables the task parallelism pattern identification.
                                 Requires --cu-inst-res and --llvm-cxxfilt-path to be set.
-    --cu-inst-res=<cuinstres>   CU instantiation result file.
-    --llvm-cxxfilt-path=<cxxfp> Path to llvm-cxxfilt executable. Required for task pattern detector
+*    --cu-inst-res=<file>   CU instantiation result file.
+*    --llvm-cxxfilt-path=<file> Path to llvm-cxxfilt executable. Required for task pattern detector
                                 if non-standard path should be used.
-    --dp-build-path=<dpbuildpath>           Path to DiscoPoP build folder [default: discopop/build]
-    --generate-data-cu-inst=<outputdir>     Generates Data_CUInst.txt file and stores it in the given directory.
+*    --dp-build-path=<dir>           Path to DiscoPoP build folder [default: discopop/build]
+*    --generate-data-cu-inst=<dir>     Generates Data_CUInst.txt file and stores it in the given directory.
                                             Stops the regular execution of the discopop_explorer.
                                             Requires --cu-xml, --dep-file, --loop-counter, --reduction.
-    -h --help                   Show this screen
+*    -h --help                   Show this screen
 """
 
 import json

--- a/discopop_wizard/classes/ExecutionConfiguration.py
+++ b/discopop_wizard/classes/ExecutionConfiguration.py
@@ -9,11 +9,13 @@
 import os
 import random
 import string
+import subprocess
 import tkinter as tk
 from json import JSONDecodeError
 from tkinter import filedialog
-from tkinter import ttk
-from typing import TextIO, List
+from typing import TextIO, List, Dict, Tuple
+
+import jsons
 
 from discopop_wizard.screens.execution import ExecutionView
 from discopop_wizard.screens.suggestions.overview import show_suggestions_overview_screen, get_suggestion_objects
@@ -21,122 +23,80 @@ from discopop_wizard.screens.utils import create_tool_tip
 
 
 class ExecutionConfiguration(object):
-    # required
-    id: str = ""
-    label: str = ""
-    description: str = ""
-    executable_name: str = ""
-    executable_arguments: str = ""
-    project_path: str = ""
-    working_copy_path: str = ""
-    linker_flags: str = ""
-    make_flags: str = ""
-    # optional
-    notes: str = ""
-    make_target: str = ""
-    explorer_flags: str = "--json=patterns.json"
     button: tk.Button
+    value_dict: Dict
 
     def __init__(self, wizard):
-        self.id = ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
+        self.value_dict = {"label": "", "description": "", "executable_name": "", "executable_arguments": "",
+                           "make_flags": "", "project_path": "", "linker_flags": "", "make_target": "", "notes": "",
+                           "working_copy_path": "",
+                           "explorer_flags": ""}
+        self.value_dict["id"] = ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
         self.wizard = wizard
 
+        # self.__extract_values_from_help_string()
+
+    def __extract_values_from_help_string(self):
+        """Read help strings of:
+        - DiscoPoP Explorer
+        - runDiscoPoP script
+        in order to automatically determine the required and optional arguments"""
+        targets: List[Tuple[str, str]] = [  # [(name, executable)]
+            ("rundiscopop", self.wizard.settings.discopop_build_dir + "/scripts/runDiscoPoP"),
+            ("explorer", "discopop_explorer")
+        ]
+        for target_name, target_executable in targets:
+            # get help string
+            tmp = subprocess.run([target_executable, '--help'], stdout=subprocess.PIPE)
+            help_string = tmp.stdout.decode('utf-8')
+            for line in help_string.split("\n"):
+                line = line.replace("\t", " ")
+                while "  " in line:
+                    line = line.replace("  ", " ")
+                if line.startswith(" "):
+                    line = line[1:]
+                if not line.startswith("* --"):
+                    continue
+                line = line[4:]  # cut off '* --'
+                # extract name and type
+                name_cutoff_index = len(line)
+                if " " in line:
+                    name_cutoff_index = min(name_cutoff_index, line.index(" "))
+                if "=" in line:
+                    name_cutoff_index = min(name_cutoff_index, line.index("="))
+                value_name = line[:name_cutoff_index]
+                if value_name == "help":
+                    continue
+                line = line[name_cutoff_index:]
+                # extract type if present
+                value_type = "bool"
+                if "<" in line and ">" in line:
+                    left_index = line.index("<") + 1
+                    right_index = line.index(">")
+                    value_type = line[left_index: right_index]
+                # add value to dictionaries
+                self.value_dict[target_name + "_" + value_name] = ""
+                # self.type_dict[target_name + "_" + value_name] = value_type
+
     def get_as_button(self, wizard, main_screen_obj, parent_frame: tk.Frame, all_buttons: List[tk.Button]) -> tk.Button:
-        button = tk.Button(parent_frame, text=self.label)
-        button.config(command=lambda: self.highlight_and_update_notebook_screens(wizard, main_screen_obj, button, all_buttons))
+        button = tk.Button(parent_frame, text=self.value_dict["label"])
+        button.config(
+            command=lambda: self.highlight_and_update_notebook_screens(wizard, main_screen_obj, button, all_buttons))
         self.button = button
         return button
 
-    def init_from_dict(self, loaded: dict):
-        for key in loaded:
-            self.__dict__[key] = loaded[key]
+    def init_from_json(self, json_file: TextIO):
+        json_str = ""
+        for line in json_file.readlines():
+            json_str += line
+        self.value_dict = {**self.value_dict, **jsons.loads(json_str)}  # merge both dictionaries
 
-    def init_from_script(self, script: TextIO):
-        for line in script.readlines():
-            line = line.replace("\n", "")
-            if line.startswith("#ID="):
-                self.id = line[line.index("=") + 1:]
-            if line.startswith("#LABEL="):
-                self.label = line[line.index("=") + 1:]
-            if line.startswith("#DESCRIPTION="):
-                self.description = line[line.index("=") + 1:]
-            if line.startswith("#EXE_NAME="):
-                self.executable_name = line[line.index("=") + 1:]
-            if line.startswith("#EXE_ARGS="):
-                self.executable_arguments = line[line.index("=") + 1:]
-            if line.startswith("#MAKE_FLAGS="):
-                self.make_flags = line[line.index("=") + 1:]
-            if line.startswith("#PROJECT_PATH="):
-                self.project_path = line[line.index("=") + 1:]
-                self.working_copy_path = self.project_path + "/.discopop"
-            if line.startswith("#PROJECT_LINKER_FLAGS="):
-                self.linker_flags = line[line.index("=") + 1:]
-            if line.startswith("#MAKE_TARGET="):
-                self.make_target = line[line.index("=") + 1:]
-            if line.startswith("#NOTES="):
-                self.notes = line[line.index("=") + 1:]
+    def get_values_as_json_string(self) -> str:
+        """returns a representation of the settings which will be stored in a configuration file."""
+        return jsons.dumps(self.value_dict)
 
-    def init_from_values(self, values: dict):
-        """values stems from reading the 'add_configuration' form."""
-        for key in values:
-            values[key] = values[key].replace("\n", ";;")
-        self.id = values["ID"]
-        self.label = values["Label: "]
-        self.description = values["Description: "]
-        self.executable_name = values["Executable name: "]
-        self.executable_arguments = values["Executable arguments: "]
-        self.make_flags = values["Make flags: "]
-        self.project_path = values["Project path: "]
-        self.working_copy_path = self.project_path + "/.discopop"
-        self.linker_flags = values["Project linker flags: "]
-        self.notes = values["Additional notes:"]
-        self.make_target = values["Make target: "]
-
-    def get_as_executable_script(self) -> str:
-        """returns a representation of the configuration which will be stored in a script file
-         and thus can be executed by the wizard as well as via a regular invocation."""
-        # define string representation of the current configuration
-        config_str = "### BEGIN CONFIG ###\n"
-        config_str += "#ID=" + self.id + "\n"
-        config_str += "#LABEL=" + self.label + "\n"
-        config_str += "#DESCRIPTION=" + self.description + "\n"
-        config_str += "#EXE_NAME=" + self.executable_name + "\n"
-        config_str += "#EXE_ARGS=" + self.executable_arguments + "\n"
-        config_str += "#MAKE_FLAGS=" + self.make_flags + "\n"
-        config_str += "#PROJECT_PATH=" + self.project_path + "\n"
-        config_str += "#PROJECT_LINKER_FLAGS=" + self.linker_flags + "\n"
-        config_str += "#MAKE_TARGET=" + self.make_target + "\n"
-        config_str += "#NOTES=" + self.notes + "\n"
-        config_str += "### END CONFIG ###\n\n"
-
-        # assemble command for execution
-        command = ""
-        # settings
-        command = self.wizard.settings.discopop_build_dir + "/scripts/runDiscoPoP "
-        command += "--llvm-clang \"" + self.wizard.settings.clang + "\" "
-        command += "--llvm-clang++ \"" + self.wizard.settings.clangpp + "\" "
-        command += "--llvm-ar \"" + self.wizard.settings.llvm_ar + "\" "
-        command += "--llvm-link \"" + self.wizard.settings.llvm_link + "\" "
-        command += "--llvm-dis \"" + self.wizard.settings.llvm_dis + "\" "
-        command += "--llvm-opt \"" + self.wizard.settings.llvm_opt + "\" "
-        command += "--llvm-llc \"" + self.wizard.settings.llvm_llc + "\" "
-        command += "--gllvm \"" + self.wizard.settings.go_bin + "\" "
-        # execution configuration
-        command += "--project \"" + self.project_path + "\" "
-        command += "--linker-flags \"" + self.linker_flags + "\" "
-        command += "--executable-name \"" + self.executable_name + "\" "
-        command += "--executable-arguments \"" + self.executable_arguments + "\" "
-        command += "--make-flags \"" + self.make_flags + "\" "
-        command += "--explorer-flags \"" + self.explorer_flags + "\" "
-
-        # add configuration to resulting string
-        script_str = ""
-        script_str += config_str
-        # add invocation of actual executable to resulting string
-        script_str += command
-        return script_str
-
-    def highlight_and_update_notebook_screens(self, wizard, main_screen_obj, pressed_button: tk.Button, all_buttons: List[tk.Button]):
+    def highlight_and_update_notebook_screens(self, wizard, main_screen_obj, pressed_button: tk.Button,
+                                              all_buttons: List[tk.Button]):
         # remove previous highlights
         for configuration_button in all_buttons:
             configuration_button.configure(state=tk.NORMAL)
@@ -181,15 +141,15 @@ class ExecutionConfiguration(object):
         # show input fields
         label = tk.Entry(canvas)
         label.grid(row=1, column=2, sticky='ew')
-        label.insert(tk.END, self.label)
+        label.insert(tk.END, self.value_dict["label"])
         create_tool_tip(label, "Name of the configuration. Used to distinguish configurations in the main menu.")
 
         description = tk.Entry(canvas)
         description.grid(row=2, column=2, sticky='ew')
-        description.insert(tk.END, self.description)
+        description.insert(tk.END, self.value_dict["description"])
 
         executable_name = tk.Entry(canvas)
-        executable_name.insert(tk.END, self.executable_name)
+        executable_name.insert(tk.END, self.value_dict["executable_name"])
         executable_name.grid(row=3, column=2, sticky='ew')
         create_tool_tip(executable_name,
                         "Name of the executable which is created when building the target project. The name will be "
@@ -197,19 +157,19 @@ class ExecutionConfiguration(object):
 
         executable_args = tk.Entry(canvas)
         executable_args.grid(row=4, column=2, sticky='ew')
-        executable_args.insert(tk.END, self.executable_arguments)
+        executable_args.insert(tk.END, self.value_dict["executable_arguments"])
         create_tool_tip(executable_args,
                         "Specify arguments which shall be forwarded to the call of the created executable for the "
                         "profiling.")
 
         make_flags = tk.Entry(canvas)
         make_flags.grid(row=5, column=2, sticky='ew')
-        make_flags.insert(tk.END, str(self.make_flags))
+        make_flags.insert(tk.END, str(self.value_dict["make_flags"]))
         create_tool_tip(make_flags, "Specified flags will be forwarded to Make during the build of the target project.")
 
         project_path = tk.Entry(canvas)
         project_path.grid(row=6, column=2, sticky='ew')
-        project_path.insert(tk.END, self.project_path)
+        project_path.insert(tk.END, self.value_dict["project_path"])
         create_tool_tip(project_path, "Path to the project which shall be analyzed for potential parallelism.")
 
         def overwrite_with_selection(target: tk.Entry):
@@ -223,18 +183,18 @@ class ExecutionConfiguration(object):
 
         project_linker_flags = tk.Entry(canvas)
         project_linker_flags.grid(row=7, column=2, sticky='ew')
-        project_linker_flags.insert(tk.END, self.linker_flags)
+        project_linker_flags.insert(tk.END, self.value_dict["linker_flags"])
         create_tool_tip(project_linker_flags,
                         "Linker flags which need to be passed to the build system in order to create a valid "
                         "executable.")
 
         make_target = tk.Entry(canvas)
         make_target.grid(row=8, column=2, sticky='ew')
-        make_target.insert(tk.END, self.make_target)
+        make_target.insert(tk.END, self.value_dict["make_target"])
 
         additional_notes = tk.Text(canvas, height=10)
         additional_notes.grid(row=9, column=2, sticky='ew')
-        additional_notes.insert(tk.END, self.notes)
+        additional_notes.insert(tk.END, self.value_dict["notes"])
         create_tool_tip(additional_notes, "Can be used to store notes regarding the configuration.")
 
         # show buttons
@@ -272,30 +232,36 @@ class ExecutionConfiguration(object):
         return "normal"
 
     def save_changes(self, wizard, main_screen_obj,
-                     label: tk.Entry, description: tk.Entry, executable_name: tk.Entry, executable_args: tk.Entry,
-                     make_flags: tk.Entry, project_path: tk.Entry, project_linker_flags: tk.Entry,
-                     make_target: tk.Entry, additional_notes: tk.Entry, rebuild_configurations_frame=True):
+                     label,
+                     description, executable_name,
+                     executable_args, make_flags,
+                     project_path, project_linker_flags,
+                     make_target,
+                     additional_notes,
+                     rebuild_configurations_frame=True
+                     ):
 
-        # update execution_configuration
-        self.label = label.get()
-        self.description = description.get()
-        self.executable_name = executable_name.get()
-        self.executable_arguments = executable_args.get()
-        self.make_flags = make_flags.get()
-        self.project_path = project_path.get()
-        self.working_copy_path = self.project_path + "/.discopop"
-        self.linker_flags = project_linker_flags.get()
-        self.make_target = make_target.get()
-        self.notes = additional_notes.get("1.0", tk.END)
+        # update execution configuration
+        self.value_dict["label"] = label.get()
+        self.value_dict["description"] = description.get()
+        self.value_dict["executable_name"] = executable_name.get()
+        self.value_dict["executable_arguments"] = executable_args.get()
+        self.value_dict["make_flags"] = make_flags.get()
+        self.value_dict["project_path"] = project_path.get()
+        self.value_dict["working_copy_path"] = self.value_dict["project_path"] + "/.discopop"
+        self.value_dict["linker_flags"] = project_linker_flags.get()
+        self.value_dict["make_target"] = make_target.get()
+        self.value_dict["notes"] = additional_notes.get("1.0", tk.END)
 
+        # construct config path
         config_path = os.path.join(wizard.config_dir, "execution_configurations",
-                                   str(self.id) + "_" + self.label + ".sh")
+                                   str(self.value_dict["id"]) + "_" + self.value_dict["label"] + ".json")
         # remove old config if present
         if os.path.exists(config_path):
             os.remove(config_path)
         # write config to file
         with open(config_path, "w+") as f:
-            f.write(self.get_as_executable_script())
+            f.write(self.get_values_as_json_string())
 
         if rebuild_configurations_frame:  # used to prevent de-selecting button on execution
             main_screen_obj.build_configurations_frame(wizard)
@@ -306,7 +272,7 @@ class ExecutionConfiguration(object):
                              details_frame: tk.Frame):
         # delete configuration file if it exists
         config_path = os.path.join(wizard.config_dir, "execution_configurations",
-                                   self.id + "_" + self.label + ".sh")
+                                   str(self.value_dict["id"]) + "_" + self.value_dict["label"] + ".json")
         if os.path.exists(config_path):
             os.remove(config_path)
 
@@ -316,14 +282,19 @@ class ExecutionConfiguration(object):
             c.destroy()
 
     def execute_configuration(self, wizard, main_screen_obj,
-                              label: tk.Entry, description: tk.Entry, executable_name: tk.Entry,
-                              executable_args: tk.Entry,
-                              make_flags: tk.Entry, project_path: tk.Entry, project_linker_flags: tk.Entry,
-                              make_target: tk.Entry, additional_notes: tk.Entry):
+                              label,
+                              description, executable_name,
+                              executable_args, make_flags,
+                              project_path, project_linker_flags,
+                              make_target,
+                              additional_notes
+                              ):
         # save changes
-        self.save_changes(wizard, main_screen_obj, label, description, executable_name,
+        self.save_changes(wizard, main_screen_obj, label,
+                          description, executable_name,
                           executable_args, make_flags,
-                          project_path, project_linker_flags, make_target,
+                          project_path, project_linker_flags,
+                          make_target,
                           additional_notes, rebuild_configurations_frame=False)
 
         # create execution view and update results frame

--- a/discopop_wizard/classes/Suggestion.py
+++ b/discopop_wizard/classes/Suggestion.py
@@ -54,7 +54,7 @@ class Suggestion(object):
 
         # load file mapping from project path
         file_mapping: dict[int, str] = dict()
-        with open(os.path.join(execution_configuration.working_copy_path, "FileMapping.txt"), "r") as f:
+        with open(os.path.join(execution_configuration.value_dict["working_copy_path"], "FileMapping.txt"), "r") as f:
             for line in f.readlines():
                 line = line.replace("\n", "")
                 split_line = line.split("\t")

--- a/discopop_wizard/screens/execution.py
+++ b/discopop_wizard/screens/execution.py
@@ -53,12 +53,12 @@ class ExecutionView(object):
         command += "--llvm-llc \"" + self.wizard.settings.llvm_llc + "\" "
         command += "--gllvm \"" + self.wizard.settings.go_bin + "\" "
         # execution configuration
-        command += "--project \"" + self.execution_configuration.project_path + "\" "
-        command += "--linker-flags \"" + self.execution_configuration.linker_flags + "\" "
-        command += "--executable-name \"" + self.execution_configuration.executable_name + "\" "
-        command += "--executable-arguments \"" + self.execution_configuration.executable_arguments + "\" "
-        command += "--make-flags \"" + self.execution_configuration.make_flags + "\" "
-        command += "--explorer-flags \"" + self.execution_configuration.explorer_flags + "\" "
+        command += "--project \"" + self.execution_configuration.value_dict["project_path"] + "\" "
+        command += "--linker-flags \"" + self.execution_configuration.value_dict["linker_flags"] + "\" "
+        command += "--executable-name \"" + self.execution_configuration.value_dict["executable_name"] + "\" "
+        command += "--executable-arguments \"" + self.execution_configuration.value_dict["executable_arguments"] + "\" "
+        command += "--make-flags \"" + self.execution_configuration.value_dict["make_flags"] + "\" "
+        command += "--explorer-flags \"" + self.execution_configuration.value_dict["explorer_flags"] + "\" "
 
         return command
 

--- a/discopop_wizard/screens/main.py
+++ b/discopop_wizard/screens/main.py
@@ -103,8 +103,10 @@ class MainScreen(object):
     def load_execution_configurations(self, config_dir: str) -> List[ExecutionConfiguration]:
         execution_configs: List[ExecutionConfiguration] = []
         for filename in os.listdir(os.path.join(config_dir, "execution_configurations")):
-            with open(os.path.join(os.path.join(config_dir, "execution_configurations"), filename), 'r') as script:
+            if not filename.endswith(".json"):
+                continue
+            with open(os.path.join(os.path.join(config_dir, "execution_configurations"), filename), 'r') as json_file:
                 config = ExecutionConfiguration(self.wizard)
-                config.init_from_script(script)
+                config.init_from_json(json_file)
                 execution_configs.append(config)
         return execution_configs

--- a/discopop_wizard/screens/suggestions/overview.py
+++ b/discopop_wizard/screens/suggestions/overview.py
@@ -60,7 +60,7 @@ def show_suggestions_overview_screen(wizard, details_frame: tk.Frame, execution_
 
 
 def get_suggestion_objects(execution_configuration_obj) -> List[Suggestion]:
-    suggestions_path = os.path.join(execution_configuration_obj.working_copy_path, "patterns.json")
+    suggestions_path = os.path.join(execution_configuration_obj.value_dict["working_copy_path"], "patterns.json")
 
     suggestions_list: List[Suggestion] = []
     with open(suggestions_path, "r") as f:

--- a/scripts/runDiscoPoP
+++ b/scripts/runDiscoPoP
@@ -214,6 +214,12 @@ done
 
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
+# show helptext
+if [ "$HELP" = true ]; then
+    echo "$HELPTEXT"
+    exit 0
+fi
+
 # this tool should not receive any positional arguments
 if [[ -n $1 ]]; then
   log -e "There should not be any positional arguments:"
@@ -241,12 +247,6 @@ cd .discopop
 PROJECT=$PROJECT/.discopop
 
 GLLVM_LOG=$PROJECT/gllvm_log.txt
-
-# show helptext
-if [ "$HELP" = true ]; then
-    echo "$HELPTEXT"
-    exit 0
-fi
 
 #####
 # show configuration

--- a/scripts/runDiscoPoP
+++ b/scripts/runDiscoPoP
@@ -358,7 +358,6 @@ tmp="$(./${EXECUTABLE_NAME}_dp ${EXECUTABLE_ARGUMENTS})"
 #####
 
 log -i "Looking for parallelization opportunities..."
-log -i "PYTHONPATH=$PYTHONPATH_FLAG discopop_explorer --dep-file=${EXECUTABLE_NAME}_dp_dep.txt ${EXPLORER_FLAGS}"
 PATTERNS=$(PYTHONPATH=$PYTHONPATH_FLAG discopop_explorer --dep-file=${EXECUTABLE_NAME}_dp_dep.txt ${EXPLORER_FLAGS})
 
 # write patterns to file

--- a/scripts/runDiscoPoP
+++ b/scripts/runDiscoPoP
@@ -19,30 +19,30 @@ HELPTEXT="*** DiscoPoP Execution Wizard ***
 Use this tool to analyze a project that is built using Makefiles
 
 REQUIRED ARGUMENTS: Please use absolut paths!
-* --gllvm <dir>         path to a directory with gllvm executables
+ --gllvm <dir>         path to a directory with gllvm executables
                         (gclang, gclang++, get-bc, gsanity-check)
-* --project <dir>       path to the directory that contains your makefile
-* --executable-name <string> the name of the executable that is built and analyzed
+ --project <dir>       path to the directory that contains your makefile
+ --executable-name <string> the name of the executable that is built and analyzed
 
 OPTIONAL ARGUMENTS:
-* --llvm-clang <file>    path to clang executable
-* --llvm-clang++ <file>  path to clang++ executable
-* --llvm-ar <file>       path to llvm-ar executable
-* --llvm-link <file>     path to llvm-link executable
-* --llvm-dis <file>      path to llvm-dis executable
-* --llvm-opt <file>      path to opt executable
-* --llvm-llc <file>      path to llc executable
-* --executable-arguments <string>
+ --llvm-clang <file>    path to clang executable
+ --llvm-clang++ <file>  path to clang++ executable
+ --llvm-ar <file>       path to llvm-ar executable
+ --llvm-link <file>     path to llvm-link executable
+ --llvm-dis <file>      path to llvm-dis executable
+ --llvm-opt <file>      path to opt executable
+ --llvm-llc <file>      path to llc executable
+ --executable-arguments <string>
                           run your application with these arguments
-* --linker-flags <string>   if your build requires to link other libraries
+ --linker-flags <string>   if your build requires to link other libraries
                           please provide the necessary linker flags. e.g. -lm
-* --make-target <string>   specify a specific Make target to be built,
+ --make-target <string>   specify a specific Make target to be built,
                           if not specified the default make target is used.
-* --make-flags <string>     specify flags which will be passed through to make.
-* --explorer-flags <string> will be passed through to the DiscoPoP Explorer.
-* --python-path <dir>     path to python binary folder
-* --help or -h,            show this text and exit.
-* --verbose or -v,         show verbose output.
+ --make-flags <string>     specify flags which will be passed through to make.
+ --explorer-flags <string> will be passed through to the DiscoPoP Explorer.
+ --python-path <dir>     path to python binary folder
+ --help or -h,            show this text and exit.
+ --verbose or -v,         show verbose output.
 "
 
 #####
@@ -358,6 +358,7 @@ tmp="$(./${EXECUTABLE_NAME}_dp ${EXECUTABLE_ARGUMENTS})"
 #####
 
 log -i "Looking for parallelization opportunities..."
+log -i "PYTHONPATH=$PYTHONPATH_FLAG discopop_explorer --dep-file=${EXECUTABLE_NAME}_dp_dep.txt ${EXPLORER_FLAGS}"
 PATTERNS=$(PYTHONPATH=$PYTHONPATH_FLAG discopop_explorer --dep-file=${EXECUTABLE_NAME}_dp_dep.txt ${EXPLORER_FLAGS})
 
 # write patterns to file

--- a/scripts/runDiscoPoP
+++ b/scripts/runDiscoPoP
@@ -19,30 +19,30 @@ HELPTEXT="*** DiscoPoP Execution Wizard ***
 Use this tool to analyze a project that is built using Makefiles
 
 REQUIRED ARGUMENTS: Please use absolut paths!
- --gllvm <path>         path to a directory with gllvm executables
+* --gllvm <dir>         path to a directory with gllvm executables
                         (gclang, gclang++, get-bc, gsanity-check)
- --project <path>       path to the directory that contains your makefile
- --executable-name <name> the name of the executable that is built and analyzed
+* --project <dir>       path to the directory that contains your makefile
+* --executable-name <string> the name of the executable that is built and analyzed
 
 OPTIONAL ARGUMENTS:
- --llvm-clang <path>    path to clang executable
- --llvm-clang++ <path>  path to clang++ executable
- --llvm-ar <path>       path to llvm-ar executable
- --llvm-link <path>     path to llvm-link executable
- --llvm-dis <path>      path to llvm-dis executable
- --llvm-opt <path>      path to opt executable
- --llvm-llc <path>      path to llc executable
- --executable-arguments <args>
+* --llvm-clang <file>    path to clang executable
+* --llvm-clang++ <file>  path to clang++ executable
+* --llvm-ar <file>       path to llvm-ar executable
+* --llvm-link <file>     path to llvm-link executable
+* --llvm-dis <file>      path to llvm-dis executable
+* --llvm-opt <file>      path to opt executable
+* --llvm-llc <file>      path to llc executable
+* --executable-arguments <string>
                           run your application with these arguments
- --linker-flags <flags>   if your build requires to link other libraries
+* --linker-flags <string>   if your build requires to link other libraries
                           please provide the necessary linker flags. e.g. -lm
- --make-target <target>   specify a specific Make target to be built,
+* --make-target <string>   specify a specific Make target to be built,
                           if not specified the default make target is used.
- --make-flags <flags>     specify flags which will be passed through to make.
- --explorer-flags <flags> will be passed through to the DiscoPoP Explorer.
- --python-path <path>     path to python binary folder
- --help or -h,            show this text and exit.
- --verbose or -v,         show verbose output.
+* --make-flags <string>     specify flags which will be passed through to make.
+* --explorer-flags <string> will be passed through to the DiscoPoP Explorer.
+* --python-path <dir>     path to python binary folder
+* --help or -h,            show this text and exit.
+* --verbose or -v,         show verbose output.
 "
 
 #####


### PR DESCRIPTION
- Store and Load execution configurations to / from JSON files
- Cleanup help strings of discopop_explorer and runDiscoPoP to follow a similar format
  -  originally, the idea was to parse it automatically, has been discarded as this feature is not required at the moment.