### PR TITLE
Remove duplicate child/calls edge; Function CUs now know their children and vice versa, refactorings

### DIFF
--- a/discopop_explorer/PETGraphX.py
+++ b/discopop_explorer/PETGraphX.py
@@ -283,9 +283,9 @@ class PETGraphX(object):
 
             for idx_1, sink_cu_id in enumerate(sink_cu_ids):
                 for idx_2, source_cu_id in enumerate(source_cu_ids):
-                    print("\nAdding Dep: ", idx, "/", len(dependencies_list))
-                    print("sink: ", sink_cu_id, idx_1, "/", len(sink_cu_ids))
-                    print("source: ", source_cu_id, idx_2, "/", len(source_cu_ids))
+                    print("Adding Dep: ", idx, "/", len(dependencies_list))
+                    #print("sink: ", sink_cu_id, idx_1, "/", len(sink_cu_ids))
+                    #print("source: ", source_cu_id, idx_2, "/", len(source_cu_ids))
 
                     sink_node = g.nodes[sink_cu_id]["data"]
                     source_node = g.nodes[source_cu_id]["data"]
@@ -303,9 +303,7 @@ class PETGraphX(object):
                         continue
                     if sink_cu_id and source_cu_id:
                         if sink_cu_id != source_cu_id:
-                            print("Pre-parse dep")
                             g.add_edge(sink_cu_id, source_cu_id, data=parse_dependency(dep))
-                            print("Post parse dep")
         return cls(g, reduction_vars, pos)
 
     def show(self):

--- a/discopop_explorer/PETGraphX.py
+++ b/discopop_explorer/PETGraphX.py
@@ -76,8 +76,9 @@ class MWType(Enum):
     BARRIER_WORKER = 5
 
 
-NodeID = str # fileID:nodeID
-LineID = str # fileID:lineNr
+NodeID = str  # fileID:nodeID
+LineID = str  # fileID:lineNr
+
 
 class Dependency:
     etype: EdgeType
@@ -91,6 +92,7 @@ class Dependency:
 
     def __str__(self):
         return self.var_name if self.var_name is not None else str(self.etype)
+
 
 class CUNode:
     id: NodeID
@@ -149,7 +151,11 @@ class CUNode:
         return self.id
 
     def __eq__(self, other):
-        return isinstance(other, CUNode) and other.file_id == self.file_id and other.node_id == self.node_id
+        return (
+            isinstance(other, CUNode)
+            and other.file_id == self.file_id
+            and other.node_id == self.node_id
+        )
 
     def __hash__(self):
         return hash(self.id)
@@ -284,8 +290,8 @@ class PETGraphX(object):
             for idx_1, sink_cu_id in enumerate(sink_cu_ids):
                 for idx_2, source_cu_id in enumerate(source_cu_ids):
                     print("Adding Dep: ", idx, "/", len(dependencies_list))
-                    #print("sink: ", sink_cu_id, idx_1, "/", len(sink_cu_ids))
-                    #print("source: ", source_cu_id, idx_2, "/", len(source_cu_ids))
+                    # print("sink: ", sink_cu_id, idx_1, "/", len(sink_cu_ids))
+                    # print("source: ", source_cu_id, idx_2, "/", len(source_cu_ids))
 
                     sink_node = g.nodes[sink_cu_id]["data"]
                     source_node = g.nodes[source_cu_id]["data"]
@@ -570,7 +576,7 @@ class PETGraphX(object):
                     root_loop,
                     root_children_cus,
                     root_children_loops,
-                    loops_start_lines=loop_start_lines
+                    loops_start_lines=loop_start_lines,
                 )
             ]
             filtered_deps = [
@@ -841,7 +847,7 @@ class PETGraphX(object):
         root_loop: CUNode,
         children_cus: List[CUNode],
         children_loops: List[CUNode],
-        loops_start_lines: Optional[LineID] = None
+        loops_start_lines: Optional[List[LineID]] = None,
     ) -> bool:
         """Checks, whether a variable is read-only in loop body
 

--- a/discopop_explorer/PETGraphX.py
+++ b/discopop_explorer/PETGraphX.py
@@ -877,13 +877,13 @@ class PETGraphX(object):
         :param node: current node
         :return: number of iterations
         """
-        parent = self.in_edges(node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+        parent = self.in_edges(node.id, EdgeType.CHILD)
 
         while parent:
             node = self.node_at(parent[0][0])
             if node.type == NodeType.FUNC:
-                break
-            parent = self.in_edges(node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+                return node
+            parent = self.in_edges(node.id, EdgeType.CHILD)
 
         return node
 

--- a/discopop_explorer/PETGraphX.py
+++ b/discopop_explorer/PETGraphX.py
@@ -912,17 +912,12 @@ class PETGraphX(object):
         """Finds the parent of a node
 
         :param node: current node
-        :return: number of iterations
+        :return: node of parent function
         """
-        parent = self.in_edges(node.id, EdgeType.CHILD)
-
-        while parent:
-            node = self.node_at(parent[0][0])
-            if node.type == NodeType.FUNC:
-                return node
-            parent = self.in_edges(node.id, EdgeType.CHILD)
-
-        return node
+        if node.type == NodeType.FUNC:
+            return node
+        assert node.parent_function_id
+        return self.node_at(node.parent_function_id)
 
     def get_left_right_subtree(self, target: CUNode, right_subtree: bool) -> List[CUNode]:
         """Searches for all subnodes of main which are to the left or to the right of the specified node

--- a/discopop_explorer/PETGraphX.py
+++ b/discopop_explorer/PETGraphX.py
@@ -505,8 +505,8 @@ class PETGraphX(object):
         """
         return [self.node_at(t) for s, t, d in self.out_edges(root.id, EdgeType.SUCCESSOR)]
 
-    def direct_children(self, root: CUNode) -> List[CUNode]:
-        """Gets only direct children of any type
+    def direct_children_or_called_nodes(self, root: CUNode) -> List[CUNode]:
+        """Gets direct children of any type. Also includes nodes of called functions
 
         :param root: root node
         :return: list of direct children
@@ -515,9 +515,20 @@ class PETGraphX(object):
             self.node_at(t)
             for s, t, d in self.out_edges(root.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
         ]
+    
+    def direct_children(self, root: CUNode) -> List[CUNode]:
+        """Gets direct children of any type. This includes called nodes!
 
-    def direct_children_of_type(self, root: CUNode, type: NodeType) -> List[CUNode]:
-        """Gets only direct children of specified type
+        :param root: root node
+        :return: list of direct children
+        """
+        return [
+            self.node_at(t)
+            for s, t, d in self.out_edges(root.id, EdgeType.CHILD)
+        ]
+
+    def direct_children_or_called_nodes_of_type(self, root: CUNode, type: NodeType) -> List[CUNode]:
+        """Gets only direct children of specified type. This includes called nodes!
 
         :param root: root node
         :param type: type of children
@@ -921,9 +932,9 @@ class PETGraphX(object):
                 visited.add(current)
 
             stack.extend(
-                self.direct_children(current)
+                self.direct_children_or_called_nodes(current)
                 if right_subtree
-                else reversed(self.direct_children(current))
+                else reversed(self.direct_children_or_called_nodes(current))
             )
         return res
 
@@ -947,7 +958,7 @@ class PETGraphX(object):
         if source == target:
             return [source]
 
-        for child in [c for c in self.direct_children(source) if c not in visited]:
+        for child in [c for c in self.direct_children_or_called_nodes(source) if c not in visited]:
             path = self.__path_rec(child, target, visited)
             if path:
                 path.insert(0, source)

--- a/discopop_explorer/generate_Data_CUInst.py
+++ b/discopop_explorer/generate_Data_CUInst.py
@@ -20,7 +20,7 @@ def __collect_children_ids(pet: PETGraphX, parent_id: NodeID, children_ids: List
     children_ids.append(parent_id)
     children_ids = list(set(children_ids))
     # collect all of its children
-    for child_node in pet.direct_children(pet.node_at(parent_id)):
+    for child_node in pet.direct_children_or_called_nodes(pet.node_at(parent_id)):
         children_ids += __collect_children_ids(pet, child_node.id, children_ids)
         children_ids = list(set(children_ids))
     return children_ids

--- a/discopop_explorer/generate_Data_CUInst.py
+++ b/discopop_explorer/generate_Data_CUInst.py
@@ -73,7 +73,7 @@ def __recursive_function_called_multiple_times_inside_function(
                 if cur_cu not in contained_cus:
                     contained_cus.append(cur_cu)
                 # append cur_cu children to queue
-                for child_edge in pet.out_edges(cur_cu.id, EdgeType.CHILD):
+                for child_edge in pet.out_edges(cur_cu.id, [EdgeType.CHILD, EdgeType.CALLSNODE]):
                     child_cu = pet.node_at(child_edge[1])
                     if child_cu not in queue and child_cu not in contained_cus:
                         queue.append(child_cu)
@@ -109,15 +109,15 @@ def __output_dependencies_of_type(
     for dep in pet.in_edges(child_id, EdgeType.DATA):
         if dep[2].dtype is not dep_type:
             continue
-        if dep[2].source is None or dep[2].var_name is None or dep[2].sink is None:
+        if dep[2].source_line is None or dep[2].var_name is None or dep[2].sink_line is None:
             continue
         # check if the CUid of the dep exists in children_ids
         if dep[0] in children_ids:
             # CUid found in children_ids. So print the line numbers of this dependence
             output_file.write(
-                cast(str, dep[2].sink)
+                cast(str, dep[2].sink_line)
                 + dep_identifier
-                + cast(str, dep[2].source)
+                + cast(str, dep[2].source_line)
                 + "|"
                 + cast(str, dep[2].var_name)
                 + ","

--- a/discopop_explorer/generate_Data_CUInst.py
+++ b/discopop_explorer/generate_Data_CUInst.py
@@ -9,11 +9,11 @@
 import os
 from typing import List, cast, TextIO
 
-from .PETGraphX import PETGraphX, NodeType, CUNode, DepType, EdgeType
+from .PETGraphX import LineID, NodeID, PETGraphX, NodeType, CUNode, DepType, EdgeType
 from .parser import parse_inputs
 
 
-def __collect_children_ids(pet: PETGraphX, parent_id: str, children_ids: List[str]):
+def __collect_children_ids(pet: PETGraphX, parent_id: NodeID, children_ids: List[NodeID]):
     if parent_id in children_ids:
         # this id has already been processed. No need to go through it again
         return children_ids
@@ -92,8 +92,8 @@ def __recursive_function_called_multiple_times_inside_function(
 
 def __output_dependencies_of_type(
     pet: PETGraphX,
-    child_id: str,
-    children_ids: List[str],
+    child_id: NodeID,
+    children_ids: List[NodeID],
     output_file: TextIO,
     dep_type: DepType,
     dep_identifier: str,
@@ -143,7 +143,7 @@ def __search_recursive_calls(pet: PETGraphX, output_file, node: CUNode):
 
         output_file.write(recursive_function_call + " ")
 
-        children_ids: List[str] = []
+        children_ids: List[NodeID] = []
         # Output RAW deps. First collect all children IDs of currently called
         # function. Then go through the CU type nodes in them and record all deps
         # that are on the cus in this list.
@@ -203,7 +203,7 @@ def wrapper(cu_xml, dep_file, loop_counter_file, reduction_file, output_dir):
     cu_instantiation_input_cpp(pet, output_dir)
 
 
-def __line_contained_in_region(test_line: str, start_line: str, end_line: str) -> bool:
+def __line_contained_in_region(test_line: LineID, start_line: LineID, end_line: LineID) -> bool:
     """check if test_line is contained in [startLine, endLine].
     Return True if so. False else.
     :param test_line: <fileID>:<line>

--- a/discopop_explorer/pattern_detection.py
+++ b/discopop_explorer/pattern_detection.py
@@ -55,7 +55,7 @@ class PatternDetectorX(object):
             if not loop_type or node.type == NodeType.LOOP:
                 if remove_dummies and node.type == NodeType.DUMMY:
                     continue
-                for s, t, e in self.pet.out_edges(node.id, EdgeType.CHILD):
+                for s, t, e in self.pet.out_edges(node.id, [EdgeType.CHILD, EdgeType.CALLSNODE]):
                     if remove_dummies and self.pet.node_at(t).type == NodeType.DUMMY:
                         dummies_to_remove.add(t)
 

--- a/discopop_explorer/pattern_detection.py
+++ b/discopop_explorer/pattern_detection.py
@@ -76,7 +76,7 @@ class PatternDetectorX(object):
     ):
         """Runs pattern discovery on the CU graph"""
         self.__merge(False, True)
-
+        self.pet.calculateFunctionMetadata()
         res = DetectionResult()
 
         # reduction before doall!

--- a/discopop_explorer/pattern_detectors/do_all_detector.py
+++ b/discopop_explorer/pattern_detectors/do_all_detector.py
@@ -71,7 +71,10 @@ def __detect_do_all(pet: PETGraphX, root_loop: CUNode) -> bool:
     :param root: root node
     :return: true if do-all
     """
-    subnodes = [pet.node_at(t) for s, t, d in pet.out_edges(root_loop.id, EdgeType.CHILD)]
+    subnodes = [
+        pet.node_at(t)
+        for s, t, d in pet.out_edges(root_loop.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+    ]
 
     for i in range(0, len(subnodes)):
         children_cache: Dict[CUNode, List[CUNode]] = dict()

--- a/discopop_explorer/pattern_detectors/geometric_decomposition_detector.py
+++ b/discopop_explorer/pattern_detectors/geometric_decomposition_detector.py
@@ -163,10 +163,10 @@ def __get_parent_iterations(pet: PETGraphX, node: CUNode) -> int:
         # prevent looping
         if node in visited:
             break
-        visited.append(node)
         if node.type == NodeType.LOOP:
             max_iter = max(1, node.loop_iterations)
             break
+        visited.append(node)
         parent = pet.in_edges(node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
 
     return max_iter

--- a/discopop_explorer/pattern_detectors/geometric_decomposition_detector.py
+++ b/discopop_explorer/pattern_detectors/geometric_decomposition_detector.py
@@ -109,10 +109,10 @@ def __test_chunk_limit(pet: PETGraphX, node: CUNode) -> Tuple[bool, Optional[int
     min_iterations_count = None
     inner_loop_iter = {}
 
-    children = pet.direct_children_of_type(node, NodeType.LOOP)
+    children = pet.direct_children_or_called_nodes_of_type(node, NodeType.LOOP)
 
-    for func_child in pet.direct_children_of_type(node, NodeType.FUNC):
-        children.extend(pet.direct_children_of_type(func_child, NodeType.LOOP))
+    for func_child in pet.direct_children_or_called_nodes_of_type(node, NodeType.FUNC):
+        children.extend(pet.direct_children_or_called_nodes_of_type(func_child, NodeType.LOOP))
 
     for child in children:
         inner_loop_iter[child.start_position()] = __iterations_count(pet, child)
@@ -183,8 +183,8 @@ def __detect_geometric_decomposition(pet: PETGraphX, root: CUNode) -> bool:
         if not (child.reduction or child.do_all):
             return False
 
-    for child in pet.direct_children_of_type(root, NodeType.FUNC):
-        for child2 in pet.direct_children_of_type(child, NodeType.LOOP):
+    for child in pet.direct_children_or_called_nodes_of_type(root, NodeType.FUNC):
+        for child2 in pet.direct_children_or_called_nodes_of_type(child, NodeType.LOOP):
             if not (child2.reduction or child2.do_all):
                 return False
 

--- a/discopop_explorer/pattern_detectors/geometric_decomposition_detector.py
+++ b/discopop_explorer/pattern_detectors/geometric_decomposition_detector.py
@@ -154,7 +154,7 @@ def __get_parent_iterations(pet: PETGraphX, node: CUNode) -> int:
     :param node: current node
     :return: number of iterations
     """
-    parent = pet.in_edges(node.id, EdgeType.CHILD)
+    parent = pet.in_edges(node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
 
     max_iter = 1
     visited = []  # used to prevent looping
@@ -167,7 +167,7 @@ def __get_parent_iterations(pet: PETGraphX, node: CUNode) -> int:
         if node.type == NodeType.LOOP:
             max_iter = max(1, node.loop_iterations)
             break
-        parent = pet.in_edges(node.id, EdgeType.CHILD)
+        parent = pet.in_edges(node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
 
     return max_iter
 

--- a/discopop_explorer/pattern_detectors/geometric_decomposition_detector.py
+++ b/discopop_explorer/pattern_detectors/geometric_decomposition_detector.py
@@ -11,11 +11,11 @@ import math
 from typing import Dict, List, Tuple, Optional
 
 from .PatternInfo import PatternInfo
-from ..PETGraphX import PETGraphX, NodeType, CUNode, EdgeType
+from ..PETGraphX import NodeID, PETGraphX, NodeType, CUNode, EdgeType
 from ..utils import classify_task_vars, get_child_loops, contains
 from ..variable import Variable
 
-__loop_iterations: Dict[str, int] = {}
+__loop_iterations: Dict[NodeID, int] = {}
 
 
 class GDInfo(PatternInfo):

--- a/discopop_explorer/pattern_detectors/pipeline_detector.py
+++ b/discopop_explorer/pattern_detectors/pipeline_detector.py
@@ -70,7 +70,7 @@ class PipelineInfo(PatternInfo):
 
         self._stages = [
             pet.node_at(t)
-            for s, t, d in pet.out_edges(node.id, EdgeType.CHILD)
+            for s, t, d in pet.out_edges(node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
             if is_pipeline_subnode(node, pet.node_at(t), children_start_lines)
         ]
 
@@ -180,7 +180,7 @@ def __detect_pipeline(pet: PETGraphX, root: CUNode, children_cache=None, dep_cac
 
     loop_subnodes = [
         pet.node_at(t)
-        for s, t, d in pet.out_edges(root.id, EdgeType.CHILD)
+        for s, t, d in pet.out_edges(root.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
         if is_pipeline_subnode(root, pet.node_at(t), children_start_lines)
     ]
 

--- a/discopop_explorer/pattern_detectors/pipeline_detector.py
+++ b/discopop_explorer/pattern_detectors/pipeline_detector.py
@@ -10,7 +10,7 @@
 from typing import List, Tuple, Dict, Set
 
 from .PatternInfo import PatternInfo
-from ..PETGraphX import PETGraphX, NodeType, CUNode, EdgeType, DepType, Dependency
+from ..PETGraphX import LineID, NodeID, PETGraphX, NodeType, CUNode, EdgeType, DepType, Dependency
 from ..utils import correlation_coefficient, classify_task_vars, contains
 
 __pipeline_threshold = 0.9
@@ -77,7 +77,7 @@ class PipelineInfo(PatternInfo):
         self.stages = [self.__output_stage(s) for s in self._stages]
 
     def __in_dep(self, node: CUNode):
-        raw: List[Tuple[str, str, Dependency]] = []
+        raw: List[Tuple[NodeID, NodeID, Dependency]] = []
         for n in self._pet.subtree_of_type(node, NodeType.CU):
             raw.extend(
                 (s, t, d)
@@ -92,7 +92,7 @@ class PipelineInfo(PatternInfo):
         return [dep for dep in raw if dep[1] in [n.id for n in nodes_before]]
 
     def __out_dep(self, node: CUNode):
-        raw: List[Tuple[str, str, Dependency]] = []
+        raw: List[Tuple[NodeID, NodeID, Dependency]] = []
         for n in self._pet.subtree_of_type(node, NodeType.CU):
             raw.extend(
                 (s, t, d)
@@ -123,7 +123,7 @@ class PipelineInfo(PatternInfo):
         )
 
 
-def is_pipeline_subnode(root: CUNode, current: CUNode, children_start_lines: List[str]) -> bool:
+def is_pipeline_subnode(root: CUNode, current: CUNode, children_start_lines: List[LineID]) -> bool:
     """Checks if node is a valid subnode for pipeline
 
     :param root: root node

--- a/discopop_explorer/pattern_detectors/task_parallelism/filter.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/filter.py
@@ -364,7 +364,7 @@ def __filter_sharing_clause(
                 to_be_removed.append(var)
                 continue
             # 2. check if task suggestion is child of same nodes as var_def_cu
-            for in_child_edge in pet.in_edges(var_def_cu.id, EdgeType.CHILD):
+            for in_child_edge in pet.in_edges(var_def_cu.id, [EdgeType.CHILD, EdgeType.CALLSNODE]):
                 parent_cu = pet.node_at(in_child_edge[0])
                 # check if task suggestion cu is reachable from parent via child edges
                 if not check_reachability(pet, suggestion._node, parent_cu, [EdgeType.CHILD]):

--- a/discopop_explorer/pattern_detectors/task_parallelism/preprocessor.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/preprocessor.py
@@ -424,7 +424,7 @@ def check_loop_scopes(pet: PETGraphX):
     (expand only) if necessary
     :param pet: PET graph"""
     for loop_cu in pet.all_nodes(NodeType.LOOP):
-        for child in pet.direct_children(loop_cu):
+        for child in pet.direct_children_or_called_nodes(loop_cu):
             if not line_contained_in_region(
                 child.start_position(), loop_cu.start_position(), loop_cu.end_position()
             ):

--- a/discopop_explorer/pattern_detectors/task_parallelism/suggesters/data_sharing_clauses.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/suggesters/data_sharing_clauses.py
@@ -38,7 +38,7 @@ def suggest_shared_clauses_for_all_tasks_in_function_body(
             # iterate over parent function(s)
             for parent_function in [
                 pet.node_at(e[0])
-                for e in pet.in_edges(ts._node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+                for e in pet.in_edges(ts._node.id, EdgeType.CHILD)
                 if pet.node_at(e[0]).type == NodeType.FUNC
             ]:
                 # get task suggestions in parent functions scope

--- a/discopop_explorer/pattern_detectors/task_parallelism/suggesters/data_sharing_clauses.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/suggesters/data_sharing_clauses.py
@@ -38,7 +38,7 @@ def suggest_shared_clauses_for_all_tasks_in_function_body(
             # iterate over parent function(s)
             for parent_function in [
                 pet.node_at(e[0])
-                for e in pet.in_edges(ts._node.id, EdgeType.CHILD)
+                for e in pet.in_edges(ts._node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
                 if pet.node_at(e[0]).type == NodeType.FUNC
             ]:
                 # get task suggestions in parent functions scope

--- a/discopop_explorer/pattern_detectors/task_parallelism/suggesters/dependency_clauses.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/suggesters/dependency_clauses.py
@@ -448,7 +448,7 @@ def __get_potential_children_of_function(pet: PETGraphX, parent_function: CUNode
     :param pet: PET Graph
     :param parent_function: function to be analyzed
     :return: List of CUNodes contained in functions body."""
-    queue = pet.direct_children(parent_function)
+    queue = pet.direct_children_or_called_nodes(parent_function)
     potential_children = []
     visited = []
     while queue:
@@ -465,7 +465,7 @@ def __get_potential_children_of_function(pet: PETGraphX, parent_function: CUNode
             parent_function.end_position(),
         ):
             potential_children.append(cur_potential_child)
-        for tmp_child in pet.direct_children(cur_potential_child):
+        for tmp_child in pet.direct_children_or_called_nodes(cur_potential_child):
             if (
                 tmp_child not in queue
                 and tmp_child not in potential_children
@@ -1101,7 +1101,7 @@ def get_function_call_parameter_rw_information_recursion_step(
 
     # get potential children of called function
     recursively_visited.append(called_function_cu)
-    queue_1 = pet.direct_children(called_function_cu)
+    queue_1 = pet.direct_children_or_called_nodes(called_function_cu)
     potential_children = []
     visited = []
     while queue_1:
@@ -1119,7 +1119,7 @@ def get_function_call_parameter_rw_information_recursion_step(
         ):
             if cur_potential_child not in potential_children:
                 potential_children.append(cur_potential_child)
-        for tmp_child in pet.direct_children(cur_potential_child):
+        for tmp_child in pet.direct_children_or_called_nodes(cur_potential_child):
             if (
                 tmp_child not in queue_1
                 and tmp_child not in potential_children
@@ -1144,7 +1144,7 @@ def get_function_call_parameter_rw_information_recursion_step(
         )
     ]:
         # find called functions
-        for child_func in pet.direct_children_of_type(child, NodeType.FUNC):
+        for child_func in pet.direct_children_or_called_nodes_of_type(child, NodeType.FUNC):
             # apply __get_function_call_parameter_rw_information
             if child not in recursively_visited:
                 ret_val = get_function_call_parameter_rw_information(
@@ -1208,7 +1208,7 @@ def get_function_call_parameter_rw_information_recursion_step(
                 ):
                     function_internal_cu_nodes.append(cur)
                 # add children to queue
-                for cur_child in pet.direct_children(cur):
+                for cur_child in pet.direct_children_or_called_nodes(cur):
                     if cur_child not in function_internal_cu_nodes and cur_child not in queue:
                         queue.append(cur_child)
             for child_cu in function_internal_cu_nodes:

--- a/discopop_explorer/pattern_detectors/task_parallelism/suggesters/dependency_clauses.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/suggesters/dependency_clauses.py
@@ -424,7 +424,7 @@ def __get_potential_parent_functions(pet: PETGraphX, sug: TaskParallelismInfo) -
     :return: List of potential parents of sug (Function CU Nodes)"""
     potential_parent_functions = [
         pet.node_at(e[0])
-        for e in pet.in_edges(sug._node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+        for e in pet.in_edges(sug._node.id, EdgeType.CHILD)
         if pet.node_at(e[0]).type == NodeType.FUNC
     ]
     if not potential_parent_functions:
@@ -432,7 +432,7 @@ def __get_potential_parent_functions(pet: PETGraphX, sug: TaskParallelismInfo) -
         # i.e. function which contains the CU.
         queue = [
             pet.node_at(e[0])
-            for e in pet.in_edges(sug._node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+            for e in pet.in_edges(sug._node.id, EdgeType.CHILD)
         ]
         found_parent = None
         while len(queue) > 0 or not found_parent:
@@ -442,7 +442,7 @@ def __get_potential_parent_functions(pet: PETGraphX, sug: TaskParallelismInfo) -
                 break
             queue += [
                 pet.node_at(e[0])
-                for e in pet.in_edges(current.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+                for e in pet.in_edges(current.id, EdgeType.CHILD)
             ]
         potential_parent_functions = [found_parent]
     return potential_parent_functions

--- a/discopop_explorer/pattern_detectors/task_parallelism/suggesters/dependency_clauses.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/suggesters/dependency_clauses.py
@@ -424,20 +424,26 @@ def __get_potential_parent_functions(pet: PETGraphX, sug: TaskParallelismInfo) -
     :return: List of potential parents of sug (Function CU Nodes)"""
     potential_parent_functions = [
         pet.node_at(e[0])
-        for e in pet.in_edges(sug._node.id, EdgeType.CHILD)
+        for e in pet.in_edges(sug._node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
         if pet.node_at(e[0]).type == NodeType.FUNC
     ]
     if not potential_parent_functions:
         # perform BFS search on incoming CHILD edges to find closest parent function,
         # i.e. function which contains the CU.
-        queue = [pet.node_at(e[0]) for e in pet.in_edges(sug._node.id, EdgeType.CHILD)]
+        queue = [
+            pet.node_at(e[0])
+            for e in pet.in_edges(sug._node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+        ]
         found_parent = None
         while len(queue) > 0 or not found_parent:
             current = queue.pop(0)
             if current.type == NodeType.FUNC:
                 found_parent = current
                 break
-            queue += [pet.node_at(e[0]) for e in pet.in_edges(current.id, EdgeType.CHILD)]
+            queue += [
+                pet.node_at(e[0])
+                for e in pet.in_edges(current.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+            ]
         potential_parent_functions = [found_parent]
     return potential_parent_functions
 

--- a/discopop_explorer/pattern_detectors/task_parallelism/suggesters/dependency_clauses.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/suggesters/dependency_clauses.py
@@ -430,20 +430,14 @@ def __get_potential_parent_functions(pet: PETGraphX, sug: TaskParallelismInfo) -
     if not potential_parent_functions:
         # perform BFS search on incoming CHILD edges to find closest parent function,
         # i.e. function which contains the CU.
-        queue = [
-            pet.node_at(e[0])
-            for e in pet.in_edges(sug._node.id, EdgeType.CHILD)
-        ]
+        queue = [pet.node_at(e[0]) for e in pet.in_edges(sug._node.id, EdgeType.CHILD)]
         found_parent = None
         while len(queue) > 0 or not found_parent:
             current = queue.pop(0)
             if current.type == NodeType.FUNC:
                 found_parent = current
                 break
-            queue += [
-                pet.node_at(e[0])
-                for e in pet.in_edges(current.id, EdgeType.CHILD)
-            ]
+            queue += [pet.node_at(e[0]) for e in pet.in_edges(current.id, EdgeType.CHILD)]
         potential_parent_functions = [found_parent]
     return potential_parent_functions
 

--- a/discopop_explorer/pattern_detectors/task_parallelism/suggesters/tasks.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/suggesters/tasks.py
@@ -235,7 +235,7 @@ def correct_task_suggestions_in_loop_body(
                             # protect RAW-Writes to shared variables with critical section
                             # i.e. find in-deps to shared variables and suggest critical section around CUs
                             # containing such cases
-                            for loop_cu_child in pet.direct_children(loop_cu):
+                            for loop_cu_child in pet.direct_children_or_called_nodes(loop_cu):
                                 for in_dep_var_name in list(
                                     set(
                                         [

--- a/discopop_explorer/pattern_detectors/task_parallelism/suggesters/tasks.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/suggesters/tasks.py
@@ -221,10 +221,7 @@ def correct_task_suggestions_in_loop_body(
                         # move pragma task line to beginning of loop body (i.e. make the entire loop body a task)
                         # set task region lines accordingly
                         # if ts._node is a direct child of loop_cu
-                        if loop_cu.id in [
-                            e[0]
-                            for e in pet.in_edges(ts._node.id, EdgeType.CHILD)
-                        ]:
+                        if loop_cu.id in [e[0] for e in pet.in_edges(ts._node.id, EdgeType.CHILD)]:
                             print(
                                 "Moving Pragma from: ",
                                 ts.pragma_line,

--- a/discopop_explorer/pattern_detectors/task_parallelism/suggesters/tasks.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/suggesters/tasks.py
@@ -223,7 +223,7 @@ def correct_task_suggestions_in_loop_body(
                         # if ts._node is a direct child of loop_cu
                         if loop_cu.id in [
                             e[0]
-                            for e in pet.in_edges(ts._node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+                            for e in pet.in_edges(ts._node.id, EdgeType.CHILD)
                         ]:
                             print(
                                 "Moving Pragma from: ",

--- a/discopop_explorer/pattern_detectors/task_parallelism/suggesters/tasks.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/suggesters/tasks.py
@@ -60,7 +60,7 @@ def detect_task_suggestions(pet: PETGraphX) -> List[PatternInfo]:
         first_dependency_line_number = first_dependency_line[first_dependency_line.index(":") + 1 :]
         for s, t, e in pet.out_edges(v.id):
             if e.etype == EdgeType.DATA:
-                dep_line = cast(str, e.sink)
+                dep_line = cast(str, e.sink_line)
                 dep_line_number = dep_line[dep_line.index(":") + 1 :]
                 if dep_line_number < first_dependency_line_number:
                     first_dependency_line = dep_line
@@ -221,7 +221,10 @@ def correct_task_suggestions_in_loop_body(
                         # move pragma task line to beginning of loop body (i.e. make the entire loop body a task)
                         # set task region lines accordingly
                         # if ts._node is a direct child of loop_cu
-                        if loop_cu.id in [e[0] for e in pet.in_edges(ts._node.id, EdgeType.CHILD)]:
+                        if loop_cu.id in [
+                            e[0]
+                            for e in pet.in_edges(ts._node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+                        ]:
                             print(
                                 "Moving Pragma from: ",
                                 ts.pragma_line,

--- a/discopop_explorer/pattern_detectors/task_parallelism/task_parallelism_detector.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/task_parallelism_detector.py
@@ -151,7 +151,7 @@ def run_detection(
 
         if node.type == NodeType.DUMMY:
             continue
-        if pet.direct_children(node):
+        if pet.direct_children_or_called_nodes(node):
             detect_mw_types(pet, node)
 
         if node.mw_type == MWType.NONE:

--- a/discopop_explorer/pattern_detectors/task_parallelism/tp_utils.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/tp_utils.py
@@ -141,7 +141,7 @@ def get_cus_inside_function(pet: PETGraphX, function_cu: CUNode) -> List[CUNode]
             # cur_cu not contained in function body
             continue
         # append children to queue
-        for e in pet.out_edges(cur_cu.id, EdgeType.CHILD):
+        for e in pet.out_edges(cur_cu.id, [EdgeType.CHILD, EdgeType.CALLSNODE]):
             child_cu = pet.node_at(e[1])
             queue.append(child_cu)
     return result_list

--- a/discopop_explorer/pattern_detectors/task_parallelism/tp_utils.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/tp_utils.py
@@ -120,30 +120,14 @@ def get_cus_inside_function(pet: PETGraphX, function_cu: CUNode) -> List[CUNode]
     :param function_cu: target function node
     :return: List[CUNode]"""
     queue: List[CUNode] = [function_cu]
-    visited: List[CUNode] = []
     result_list: List[CUNode] = []
     while len(queue) > 0:
         cur_cu = queue.pop(0)
-        # check if cur_cu was already visited
-        if cur_cu in visited:
-            continue
-        visited.append(cur_cu)
-        # check if cur_cu inside functions body
-        if line_contained_in_region(
-            cur_cu.start_position(), function_cu.start_position(), function_cu.end_position()
-        ) and line_contained_in_region(
-            cur_cu.end_position(), function_cu.start_position(), function_cu.end_position()
-        ):
-            # cur_cu contained in function body
-            if cur_cu not in result_list:
-                result_list.append(cur_cu)
-        else:
-            # cur_cu not contained in function body
-            continue
+        if cur_cu not in result_list:
+            result_list.append(cur_cu)
         # append children to queue
-        for e in pet.out_edges(cur_cu.id, [EdgeType.CHILD, EdgeType.CALLSNODE]):
-            child_cu = pet.node_at(e[1])
-            queue.append(child_cu)
+        for e in pet.out_edges(cur_cu.id, [EdgeType.CHILD]):
+            queue.append(pet.node_at(e[1]))
     return result_list
 
 

--- a/discopop_explorer/pattern_detectors/task_parallelism/tp_utils.py
+++ b/discopop_explorer/pattern_detectors/task_parallelism/tp_utils.py
@@ -274,7 +274,7 @@ def create_task_tree_helper(
         else:
             visited_func.append(current)
 
-    for child in pet.direct_children(current):
+    for child in pet.direct_children_or_called_nodes(current):
         mw_type = child.mw_type
 
         if mw_type in [MWType.BARRIER, MWType.BARRIER_WORKER, MWType.WORKER]:
@@ -616,7 +616,7 @@ def detect_mw_types(pet: PETGraphX, main_node: CUNode):
     """
 
     # first insert all the direct children of main node in a queue to use it for the BFS
-    for node in pet.direct_children(main_node):
+    for node in pet.direct_children_or_called_nodes(main_node):
         # a child node can be set to NONE or ROOT due a former detectMWNode call where it was the mainNode
         if node.mw_type == MWType.NONE or node.mw_type == MWType.ROOT:
             node.mw_type = MWType.FORK
@@ -631,7 +631,7 @@ def detect_mw_types(pet: PETGraphX, main_node: CUNode):
         # the other node
 
         # create the copy vector so that it only contains the other nodes
-        other_nodes = pet.direct_children(main_node)
+        other_nodes = pet.direct_children_or_called_nodes(main_node)
         other_nodes.remove(node)
 
         for other_node in other_nodes:
@@ -661,7 +661,7 @@ def detect_mw_types(pet: PETGraphX, main_node: CUNode):
     # check for Barrier Worker pairs
     # if two barriers don't have any dependency to each other then they create a barrierWorker pair
     # so check every barrier pair that they don't have a dependency to each other -> barrierWorker
-    direct_subnodes = pet.direct_children(main_node)
+    direct_subnodes = pet.direct_children_or_called_nodes(main_node)
     for n1 in direct_subnodes:
         if n1.mw_type == MWType.BARRIER:
             for n2 in direct_subnodes:

--- a/discopop_explorer/plugins/pipeline.py
+++ b/discopop_explorer/plugins/pipeline.py
@@ -48,7 +48,7 @@ def check_pipeline(pet: PETGraphX, root: CUNode):
 
     loop_subnodes = [
         pet.node_at(t)
-        for s, t, d in pet.out_edges(root.id, EdgeType.CHILD)
+        for s, t, d in pet.out_edges(root.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
         if is_pipeline_subnode(root, pet.node_at(t), children_start_lines)
     ]
 

--- a/discopop_explorer/plugins/pipeline.py
+++ b/discopop_explorer/plugins/pipeline.py
@@ -9,7 +9,7 @@
 from copy import deepcopy
 from typing import List
 
-from ..PETGraphX import PETGraphX, NodeType, CUNode, EdgeType
+from ..PETGraphX import LineID, PETGraphX, NodeType, CUNode, EdgeType
 from ..utils import correlation_coefficient
 
 total = 0
@@ -165,7 +165,7 @@ def get_correlation_coefficient(matrix):
     return round(correlation_coefficient(graph_vector, pipeline_vector), 2)
 
 
-def is_pipeline_subnode(root: CUNode, current: CUNode, children_start_lines: List[str]) -> bool:
+def is_pipeline_subnode(root: CUNode, current: CUNode, children_start_lines: List[LineID]) -> bool:
     """Checks if node is a valid subnode for pipeline
 
     :param root: root node

--- a/discopop_explorer/utils.py
+++ b/discopop_explorer/utils.py
@@ -226,7 +226,7 @@ def is_func_arg(pet: PETGraphX, var: str, node: CUNode) -> bool:
     if "." not in var:
         return False
     parents = [
-        pet.node_at(edge[0]) for edge in pet.in_edges(node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+        pet.node_at(edge[0]) for edge in pet.in_edges(node.id, EdgeType.CHILD)
     ]
     # add current node to parents, if it is of type FUNC
     if node.type == NodeType.FUNC:

--- a/discopop_explorer/utils.py
+++ b/discopop_explorer/utils.py
@@ -225,9 +225,7 @@ def is_func_arg(pet: PETGraphX, var: str, node: CUNode) -> bool:
         return False
     if "." not in var:
         return False
-    parents = [
-        pet.node_at(edge[0]) for edge in pet.in_edges(node.id, EdgeType.CHILD)
-    ]
+    parents = [pet.node_at(edge[0]) for edge in pet.in_edges(node.id, EdgeType.CHILD)]
     # add current node to parents, if it is of type FUNC
     if node.type == NodeType.FUNC:
         parents.append(node)

--- a/discopop_explorer/utils.py
+++ b/discopop_explorer/utils.py
@@ -225,7 +225,9 @@ def is_func_arg(pet: PETGraphX, var: str, node: CUNode) -> bool:
         return False
     if "." not in var:
         return False
-    parents = [pet.node_at(edge[0]) for edge in pet.in_edges(node.id, EdgeType.CHILD)]
+    parents = [
+        pet.node_at(edge[0]) for edge in pet.in_edges(node.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
+    ]
     # add current node to parents, if it is of type FUNC
     if node.type == NodeType.FUNC:
         parents.append(node)
@@ -305,7 +307,7 @@ def is_first_written(
                 if (
                     eraw[2].var_name == var
                     and any([n.id == e[1] for n in sub])
-                    and e[0] == eraw[2].sink
+                    and e[0] == eraw[2].sink_line
                 ):
                     res = True
                     break
@@ -349,7 +351,7 @@ def is_first_written_new(
                 if (
                     var.name in warDep[2].var_name
                     and any([n.id == dep[1] for n in tree])
-                    and dep[2].source == warDep[2].sink
+                    and dep[2].source_line == warDep[2].sink_line
                 ):
                     result = False
                     break

--- a/discopop_explorer/utils.py
+++ b/discopop_explorer/utils.py
@@ -12,10 +12,10 @@ from typing import List, Set, Dict, Tuple
 
 import numpy as np
 
-from .PETGraphX import PETGraphX, NodeType, CUNode, DepType, EdgeType, Dependency
+from .PETGraphX import LineID, NodeID, PETGraphX, NodeType, CUNode, DepType, EdgeType, Dependency
 from .variable import Variable
 
-loop_data: Dict[str, int] = {}
+loop_data: Dict[LineID, int] = {}
 
 
 def contains(list, filter):
@@ -119,7 +119,7 @@ def is_loop_index2(pet: PETGraphX, root_loop: CUNode, var_name: str) -> bool:
 #    return res
 
 
-def get_loop_iterations(line: str) -> int:
+def get_loop_iterations(line: LineID) -> int:
     """Calculates the number of iterations in specified loop
 
     :param line: start line of the loop
@@ -129,7 +129,7 @@ def get_loop_iterations(line: str) -> int:
 
 def __get_dep_of_type(
     pet: PETGraphX, node: CUNode, dep_type: DepType, reversed: bool
-) -> List[Tuple[str, str, Dependency]]:
+) -> List[Tuple[NodeID, NodeID, Dependency]]:
     """Searches all dependencies of specified type
 
     :param pet: CU graph
@@ -164,7 +164,7 @@ def __get_variables(nodes: List[CUNode]) -> Set[Variable]:
     return res
 
 
-def is_reduction_var(line: str, name: str, reduction_vars: List[Dict[str, str]]) -> bool:
+def is_reduction_var(line: LineID, name: str, reduction_vars: List[Dict[str, str]]) -> bool:
     """Determines, whether or not the given variable is reduction variable
 
     :param line: loop line number
@@ -176,7 +176,7 @@ def is_reduction_var(line: str, name: str, reduction_vars: List[Dict[str, str]])
 
 
 def is_reduction_any(
-    possible_lines: List[str], name: str, reduction_vars: List[Dict[str, str]]
+    possible_lines: List[LineID], var_name: str, reduction_vars: List[Dict[str, str]]
 ) -> bool:
     """Determines, whether or not the given variable is reduction variable
 
@@ -186,7 +186,7 @@ def is_reduction_any(
     :return: true if is reduction variable
     """
     for line in possible_lines:
-        if is_reduction_var(line, name, reduction_vars):
+        if is_reduction_var(line, var_name, reduction_vars):
             return True
 
     return False
@@ -194,8 +194,8 @@ def is_reduction_any(
 
 def is_written_in_subtree(
     var_name: str,
-    raw: Set[Tuple[str, str, Dependency]],
-    waw: Set[Tuple[str, str, Dependency]],
+    raw: Set[Tuple[NodeID, NodeID, Dependency]],
+    waw: Set[Tuple[NodeID, NodeID, Dependency]],
     tree: List[CUNode],
 ) -> bool:
     """Checks if variable is written in subtree
@@ -250,9 +250,9 @@ def is_scalar_val(var) -> bool:
 
 def is_readonly(
     var: str,
-    war: Set[Tuple[str, str, Dependency]],
-    waw: Set[Tuple[str, str, Dependency]],
-    rev_war: Set[Tuple[str, str, Dependency]],
+    war: Set[Tuple[NodeID, NodeID, Dependency]],
+    waw: Set[Tuple[NodeID, NodeID, Dependency]],
+    rev_war: Set[Tuple[NodeID, NodeID, Dependency]],
 ) -> bool:
     """Checks if variable is readonly
 
@@ -287,8 +287,8 @@ def is_global(var: str, tree: List[CUNode]) -> bool:
 
 def is_first_written(
     var: str,
-    raw: Set[Tuple[str, str, Dependency]],
-    war: Set[Tuple[str, str, Dependency]],
+    raw: Set[Tuple[NodeID, NodeID, Dependency]],
+    war: Set[Tuple[NodeID, NodeID, Dependency]],
     sub: List[CUNode],
 ) -> bool:
     """Checks whether a variable is first written inside the current node
@@ -318,10 +318,10 @@ def is_first_written(
 
 def is_first_written_new(
     var: Variable,
-    raw_deps: Set[Tuple[str, str, Dependency]],
-    war_deps: Set[Tuple[str, str, Dependency]],
-    reverse_raw_deps: Set[Tuple[str, str, Dependency]],
-    reverse_war_deps: Set[Tuple[str, str, Dependency]],
+    raw_deps: Set[Tuple[NodeID, NodeID, Dependency]],
+    war_deps: Set[Tuple[NodeID, NodeID, Dependency]],
+    reverse_raw_deps: Set[Tuple[NodeID, NodeID, Dependency]],
+    reverse_war_deps: Set[Tuple[NodeID, NodeID, Dependency]],
     tree: List[CUNode],
 ):
     """Checks whether a variable is first written inside the current node
@@ -359,7 +359,7 @@ def is_first_written_new(
 
 
 def is_read_in_subtree(
-    var: str, rev_raw: Set[Tuple[str, str, Dependency]], tree: List[CUNode]
+    var: str, rev_raw: Set[Tuple[NodeID, NodeID, Dependency]], tree: List[CUNode]
 ) -> bool:
     """Checks if variable is read in subtree
 
@@ -376,8 +376,8 @@ def is_read_in_subtree(
 
 def is_depend_in_out(
     var: Variable,
-    in_deps: List[Tuple[str, str, Dependency]],
-    out_deps: List[Tuple[str, str, Dependency]],
+    in_deps: List[Tuple[NodeID, NodeID, Dependency]],
+    out_deps: List[Tuple[NodeID, NodeID, Dependency]],
 ) -> bool:
     """there is an in and out dependency
 
@@ -395,8 +395,8 @@ def is_depend_in_out(
 
 def is_depend_in_var(
     var: Variable,
-    in_deps: List[Tuple[str, str, Dependency]],
-    raw_deps_on: Set[Tuple[str, str, Dependency]],
+    in_deps: List[Tuple[NodeID, NodeID, Dependency]],
+    raw_deps_on: Set[Tuple[NodeID, NodeID, Dependency]],
 ) -> bool:
     """Checks if variable is written inside a dependent task and read in current task
 
@@ -413,8 +413,8 @@ def is_depend_in_var(
 
 def is_depend_out_var(
     var: Variable,
-    reverse_raw_deps_on: Set[Tuple[str, str, Dependency]],
-    out_deps: List[Tuple[str, str, Dependency]],
+    reverse_raw_deps_on: Set[Tuple[NodeID, NodeID, Dependency]],
+    out_deps: List[Tuple[NodeID, NodeID, Dependency]],
 ) -> bool:
     """Checks if variable is written inside a current task and read in dependent task
 
@@ -431,10 +431,10 @@ def is_depend_out_var(
 
 def is_read_in(
     var: Variable,
-    raw_deps_on: Set[Tuple[str, str, Dependency]],
-    war_deps_on: Set[Tuple[str, str, Dependency]],
-    reverse_raw_deps_on: Set[Tuple[str, str, Dependency]],
-    reverse_war_deps_on: Set[Tuple[str, str, Dependency]],
+    raw_deps_on: Set[Tuple[NodeID, NodeID, Dependency]],
+    war_deps_on: Set[Tuple[NodeID, NodeID, Dependency]],
+    reverse_raw_deps_on: Set[Tuple[NodeID, NodeID, Dependency]],
+    reverse_war_deps_on: Set[Tuple[NodeID, NodeID, Dependency]],
     tree: List[CUNode],
 ) -> bool:
     """Check all reverse RAW dependencies (since we know that var is written in loop, because
@@ -576,8 +576,8 @@ def classify_task_vars(
     pet: PETGraphX,
     task: CUNode,
     type: str,
-    in_deps: List[Tuple[str, str, Dependency]],
-    out_deps: List[Tuple[str, str, Dependency]],
+    in_deps: List[Tuple[NodeID, NodeID, Dependency]],
+    out_deps: List[Tuple[NodeID, NodeID, Dependency]],
     used_in_task_parallelism_detection=False,
 ):
     """Classify task variables
@@ -595,7 +595,7 @@ def classify_task_vars(
     depend_in: List[Variable] = []
     depend_out: List[Variable] = []
     depend_in_out: List[Variable] = []
-    reduction: List[str] = []
+    reduction_var_names: List[str] = []
 
     left_sub_tree = pet.get_left_right_subtree(task, False)
 
@@ -671,7 +671,7 @@ def classify_task_vars(
         elif ("GeometricDecomposition" in type or "Pipeline" in type) and is_reduction_any(
             loops_start_lines, var.name, pet.reduction_vars
         ):
-            reduction.append(var.name)
+            reduction_var_names.append(var.name)
         elif is_depend_in_out(var, in_deps, out_deps):
             depend_in_out.append(var)
         elif is_depend_in_var(var, in_deps, raw_deps_on):
@@ -714,7 +714,7 @@ def classify_task_vars(
         sorted(depend_in),
         sorted(depend_out),
         sorted(depend_in_out),
-        sorted(reduction),
+        sorted(reduction_var_names),
     )
 
 

--- a/discopop_explorer/utils.py
+++ b/discopop_explorer/utils.py
@@ -481,8 +481,8 @@ def get_child_loops(pet: PETGraphX, node: CUNode) -> Tuple[List[CUNode], List[CU
         elif child.reduction:
             reduction.append(child)
 
-    for func_child in pet.direct_children_of_type(node, NodeType.FUNC):
-        for child in pet.direct_children_of_type(func_child, NodeType.LOOP):
+    for func_child in pet.direct_children_or_called_nodes_of_type(node, NodeType.FUNC):
+        for child in pet.direct_children_or_called_nodes_of_type(func_child, NodeType.LOOP):
             if child.do_all:
                 do_all.append(child)
             elif child.reduction:
@@ -654,7 +654,7 @@ def classify_task_vars(
         loop_nodes.append(task)
 
     loops_start_lines = [n.start_position() for n in loop_nodes]
-    loop_children = [c for n in loop_nodes for c in pet.direct_children(n)]
+    loop_children = [c for n in loop_nodes for c in pet.direct_children_or_called_nodes(n)]
 
     for var in vars:
         var_is_loop_index = False


### PR DESCRIPTION
- [x]  consistently use NodeID or LineID instead of str as a type to make them easy to differentiate
- [x]  remove child edges when there is a calls edge
- [ ]  improve performance by looking at the graph from a function point-of-view