### PR TITLE
Prevent do-all parallelization of FileIO

### DIFF
--- a/DiscoPoP/DiscoPoP.cpp
+++ b/DiscoPoP/DiscoPoP.cpp
@@ -607,7 +607,8 @@ void DiscoPoP::createCUs(Region *TopRegion, set <string> &globalVariablesSet,
                                              "snwprintf_s", "vwprintf", "vfwprintf", "vswprintf", "vwprintf_s",
                                              "vfwprintf_s", "vswprintf_s", "vsnwprintf_s", "ftell", "fgetpos", "fseek",
                                              "fsetpos", "rewind", "clearerr", "feof", "ferror", "perror", "remove",
-                                             "rename", "tmpfile", "tmpfile_s", "tmpnam", "tmpnam_s"};
+                                             "rename", "tmpfile", "tmpfile_s", "tmpnam", "tmpnam_s",
+                                             "__isoc99_fscanf"};
                     if(ci){
                         if(ci->getCalledFunction()){
                             if(ci->getCalledFunction()->hasName()){

--- a/DiscoPoP/DiscoPoP.cpp
+++ b/DiscoPoP/DiscoPoP.cpp
@@ -463,12 +463,12 @@ void DiscoPoP::createCUs(Region *TopRegion, set <string> &globalVariablesSet,
             // NOTE: 'instruction' --> '&*instruction'
             lid = getLID(&*instruction, fileID);
             basicBlockName = bb->getName().str();
-            
+
             // Do not allow to combine Instructions from different scopes in the source code.
             if((&*instruction)->getDebugLoc()){
                 if ((&*instruction)->getDebugLoc()->getScope() != scopeBuffer){
                     // scopes are not equal
-                    
+
                     int scopeIsParentOfBuffer = 0;
                     if(scopeBuffer){
                         scopeIsParentOfBuffer = (&*instruction)->getDebugLoc()->getScope() == scopeBuffer->getScope();
@@ -484,7 +484,7 @@ void DiscoPoP::createCUs(Region *TopRegion, set <string> &globalVariablesSet,
                         if ((! cu->readPhaseLineNumbers.empty()) || (! cu->writePhaseLineNumbers.empty()) || (! cu->returnInstructions.empty())) {
                             cu->startLine = *(cu->instructionsLineNumbers.begin());
                             cu->endLine = *(cu->instructionsLineNumbers.rbegin());
-                    
+
                             cu->basicBlockName = basicBlockName;
                             CUVector.push_back(cu);
                             suspiciousVariables.clear();
@@ -498,13 +498,13 @@ void DiscoPoP::createCUs(Region *TopRegion, set <string> &globalVariablesSet,
                             currentNode->childrenNodes.push_back(cu);
                             temp->successorCUs.push_back(cu->ID);
                             BBIDToCUIDsMap[bb->getName().str()].push_back(cu);
-                        }   
+                        }
                     }
                     // update scopeBuffer
                         scopeBuffer = (&*instruction)->getDebugLoc()->getScope();
                 }
             }
-            
+
 
             if (lid > 0) {
                 cu->instructionsLineNumbers.insert(lid);
@@ -592,7 +592,22 @@ void DiscoPoP::createCUs(Region *TopRegion, set <string> &globalVariablesSet,
                 else if (isa<CallInst>(instruction)){
                     // get the name of the called function and check if a FileIO function is called
                     CallInst *ci = cast<CallInst>(instruction);
-                    set<string> IOFunctions {"printf"};
+                    set<string> IOFunctions {"fopen", "fopen_s", "freopen", "freopen_s", "fclose", "fflush", "setbuf",
+                                             "setvbuf", "fwide", "fread", "fwrite", "fgetc", "getc", "fgets", "fputc",
+                                             "putc", "fputs", "getchar", "gets", "gets_s", "putchar", "puts", "ungetc",
+                                             "fgetwc", "getwc", "fgetws", "fputwc", "putwc", "fputws", "getwchar",
+                                             "putwchar", "ungetwc", "scanf", "fscanf", "sscanf", "scanf_s", "fscanf_s",
+                                             "sscanf_s", "vscanf", "vfscanf", "vsscanf", "vscanf_s", "vfscanf_s",
+                                             "vsscanf_s", "printf", "fprintf", "sprintf", "snprintf", "printf_s",
+                                             "fprintf_s", "sprintf_s", "snprintf_s", "vprintf", "vfprintf", "vsprintf",
+                                             "vsnprintf", "vprintf_s", "vfprintf_s", "vsprintf_s", "vsnprintf_s",
+                                             "wscanf", "fwscanf", "swscanf", "wscanf_s", "fwscanf_s", "swscanf_s",
+                                             "vwscanf", "vfwscanf", "vswscanf", "vwscanf_s", "vfwscanf_s", "vswscanf_s",
+                                             "wprintf", "fwprintf", "swprintf", "wprintf_s", "wprintf_s", "swprintf_s",
+                                             "snwprintf_s", "vwprintf", "vfwprintf", "vswprintf", "vwprintf_s",
+                                             "vfwprintf_s", "vswprintf_s", "vsnwprintf_s", "ftell", "fgetpos", "fseek",
+                                             "fsetpos", "rewind", "clearerr", "feof", "ferror", "perror", "remove",
+                                             "rename", "tmpfile", "tmpfile_s", "tmpnam", "tmpnam_s"};
                     if(ci){
                         if(ci->getCalledFunction()){
                             if(ci->getCalledFunction()->hasName()){
@@ -601,7 +616,7 @@ void DiscoPoP::createCUs(Region *TopRegion, set <string> &globalVariablesSet,
                                     cu->performsFileIO = true;
                                 }
                             }
-                            
+
                         }
                     }
                 }
@@ -756,7 +771,7 @@ void DiscoPoP::fillCUVariables(Region *TopRegion,
 
                 if (lid > (*bbCU)->endLine) {
                     bbCU = next(bbCU, 1);
-                }            
+                }
                 if (globalVariablesSet.count(varName) ||
                     programGlobalVariablesSet.count(varName)) {
                     (*bbCU)->globalVariableNames.insert(v);
@@ -2509,7 +2524,7 @@ string DiscoPoP::determineVariableName_static(Instruction *I, bool &isGlobalVari
     return ""; //getOrInsertVarName("*", builder);
 }
 
-  
+
    Value *DiscoPoP::determineVariableName_dynamic(Instruction *const I)
 {
     assert(I && "Instruction cannot be NULL \n");

--- a/DiscoPoP/DiscoPoP.cpp
+++ b/DiscoPoP/DiscoPoP.cpp
@@ -589,6 +589,22 @@ void DiscoPoP::createCUs(Region *TopRegion, set <string> &globalVariablesSet,
                         }
                     }
                 }
+                else if (isa<CallInst>(instruction)){
+                    // get the name of the called function and check if a FileIO function is called
+                    CallInst *ci = cast<CallInst>(instruction);
+                    set<string> IOFunctions {"printf"};
+                    if(ci){
+                        if(ci->getCalledFunction()){
+                            if(ci->getCalledFunction()->hasName()){
+                                if(find(IOFunctions.begin(), IOFunctions.end(), ci->getCalledFunction()->getName().str()) != IOFunctions.end()){
+                                    // Called function performs FileIO
+                                    cu->performsFileIO = true;
+                                }
+                            }
+                            
+                        }
+                    }
+                }
             }
         }
         if (cu->instructionsLineNumbers.empty()) {
@@ -2789,6 +2805,8 @@ void DiscoPoP::printNode(Node *root, bool isRoot) {
                     << endl;
             *outCUs << "\t\t<writeDataSize>" << cu->writeDataSize
                     << "</writeDataSize>" << endl;
+            *outCUs << "\t\t<performsFileIO>" << cu->performsFileIO
+                    << "</performsFileIO>" << endl;
 
             *outCUs << "\t\t<instructionsCount>" << cu->instructionsCount
                     << "</instructionsCount>" << endl;

--- a/DiscoPoP/DiscoPoP.hpp
+++ b/DiscoPoP/DiscoPoP.hpp
@@ -157,6 +157,8 @@ namespace {
         set <Variable> localVariableNames;
         set <Variable> globalVariableNames;
 
+        bool performsFileIO;
+
         // Map to record function call line numbers
         map<int, vector<Node *>> callLineTofunctionMap;
 
@@ -166,6 +168,7 @@ namespace {
             writeDataSize = 0;
             instructionsCount = 0;
             // BB = NULL;
+            performsFileIO = false;
         }
 
         void removeCU() {

--- a/discopop_explorer/PETGraphX.py
+++ b/discopop_explorer/PETGraphX.py
@@ -147,6 +147,7 @@ class CUNode:
     tp_contains_task: bool = False
     tp_contains_taskwait: bool = False
     tp_omittable: bool = False
+    performs_file_io: bool = False
 
     parent_function_id: Optional[NodeID] = None  # every node that is not a function node
     children_cu_ids: Optional[List[NodeID]] = None  # function nodes only
@@ -227,6 +228,8 @@ def parse_cu(node: ObjectifiedElement) -> CUNode:
                 for v in getattr(node.callsNode, "nodeCalled")
                 if v.get("atLine") is not None
             ]
+        if hasattr(node, "performsFileIO"):
+            n.performs_file_io = True if int(getattr(node, "performsFileIO")) == 1 else False
     return n
 
 

--- a/discopop_explorer/pattern_detectors/do_all_detector.py
+++ b/discopop_explorer/pattern_detectors/do_all_detector.py
@@ -76,6 +76,12 @@ def __detect_do_all(pet: PETGraphX, root_loop: CUNode) -> bool:
         for s, t, d in pet.out_edges(root_loop.id, [EdgeType.CHILD, EdgeType.CALLSNODE])
     ]
 
+    # check if all subnodes are parallelizable
+    for node in subnodes:
+        if node.performs_file_io:
+            # node is not reliably parallelizable as some kind of file-io is performed.
+            return False
+
     for i in range(0, len(subnodes)):
         children_cache: Dict[CUNode, List[CUNode]] = dict()
         dependency_cache: Dict[Tuple[CUNode, CUNode], Set[CUNode]] = dict()


### PR DESCRIPTION
This PR adds a check for performed FileIO operations and prevents such CUs from being parallelized in a do-all manner.

In the future, such CUs could be surrounded with critical regions.