### PR TITLE
memory profiling: check for most recent allocations first

### DIFF
--- a/rtlib/iFunctions.cpp
+++ b/rtlib/iFunctions.cpp
@@ -289,16 +289,41 @@ namespace __dp {
     string getMemoryRegionIdFromAddr(string fallback, ADDR addr){
         // check if accessed addr in knwon range. If not, return fallback immediately
         if(addr >= smallestAllocatedADDR && addr <= largestAllocatedADDR){
+            // FOR NOW, ONLY SEARCH BACKWARDS TO FIND THE LATEST ALLOCA ENTRY IN CASE MEMORY ADDRESSES ARE REUSED
+            if(allocatedMemoryRegions.size() != 0){
+                // search backwards in the list
+                auto bw_it = allocatedMemoryRegions.end();
+                bw_it--;
+                bool search_backwards = true;
 
-            bool search_forwards = true;
-            bool search_backwards = true;
-            auto fw_it = lastHitIterator;
-            auto bw_it = lastHitIterator;
+                while(true){
+                    if(*bw_it == allocatedMemoryRegions.front()){
+                        search_backwards = false;
+                    }
+                    if(get<2>(*bw_it) <= addr && get<3>(*bw_it) >= addr){
+                        lastHitIterator = bw_it;
+                        return get<1>(*bw_it);
+                    }
+
+                    if(search_backwards){
+                        bw_it--;
+                    }
+                    else{
+                        break;
+                    }
+                }
+            }
+
+
+//            bool search_forwards = true;
+//            bool search_backwards = true;
+//            auto fw_it = lastHitIterator;
+//            auto bw_it = lastHitIterator;
 
             // TODO: Remove allocated entries from allocatedMemoryRegions when leaving a functions body to keep the list as short as possible
             // Caveats: The datastructure needs to be threadsafe, as it is accessed by multiple worker threads concurrently
 
-            while(true){
+/*            while(true){
                 // search forward from lastHitIterator
                 if(search_forwards){
                     if(*fw_it == allocatedMemoryRegions.back()){
@@ -338,14 +363,7 @@ namespace __dp {
                 }     
 
             }
-
-//            for(tuple<LID, string, int64_t, int64_t, int64_t> entry : allocatedMemoryRegions){
-//                counter += 1;
-//                if(get<2>(entry) <= addr && get<3>(entry) >= addr){
-//                    cout << "HIT AT counter = " << std::to_string(counter) << "\n";
-//                    return get<1>(entry);
-//                }
-//            }
+*/
         }
         
         return fallback;


### PR DESCRIPTION
Simplifies the detection of allocations which belong to addressed memory regions.
Old code commented out as it may become relevant in the future.
Required to properly handle reuse of memory addresses