### PR TITLE
fix: do not remove empty CUs

### DIFF
--- a/DiscoPoP/DiscoPoP.cpp
+++ b/DiscoPoP/DiscoPoP.cpp
@@ -582,7 +582,7 @@ void DiscoPoP::createCUs(Region *TopRegion, set <string> &globalVariablesSet,
                         cu->instructionsLineNumbers.erase(lid);
                         cu->instructionsCount--;
                         if (cu->instructionsLineNumbers.empty()) {
-                            cu->removeCU();
+                            //cu->removeCU();
                             cu->startLine = -1;
                             cu->endLine = -1;
                         } else {
@@ -649,7 +649,7 @@ void DiscoPoP::createCUs(Region *TopRegion, set <string> &globalVariablesSet,
             }
         }
         if (cu->instructionsLineNumbers.empty()) {
-            cu->removeCU();
+            //cu->removeCU();
             cu->startLine = -1;
             cu->endLine = -1;
         } else {


### PR DESCRIPTION
The removal of empty CUs can lead to broken successor graphs in some cases.
This PR allows empty CUs (such without instructions lines). Since no Dependencies will be mapped to those CUs, there should be no effect on the analysis results.