### PR TITLE
gui: added preview for static and dynamic dependencies

### DIFF
--- a/discopop_wizard/screens/suggestions/overview.py
+++ b/discopop_wizard/screens/suggestions/overview.py
@@ -49,11 +49,17 @@ def show_suggestions_overview_screen(wizard, details_frame: tk.Frame, execution_
     with open(execution_configuration_obj.value_dict["working_copy_path"] + "/Data.xml", "r") as f:
         cu_display_widget.set_text(f.read())
     result_notebook.add(cu_display_widget.frame, text="CU's")
-    # add Dependency preview
-    dep_display_widget = ScrollableTextWidget(result_notebook)
+    # add dynamic dependency preview
+    dynamic_dep_display_widget = ScrollableTextWidget(result_notebook)
     with open(execution_configuration_obj.value_dict["working_copy_path"] + "/" + execution_configuration_obj.value_dict["executable_name"] + "_dp_dep.txt", "r") as f:
-        dep_display_widget.set_text(f.read())
-    result_notebook.add(dep_display_widget.frame, text="DEP's")
+        dynamic_dep_display_widget.set_text(f.read())
+    result_notebook.add(dynamic_dep_display_widget.frame, text="Dynamic DEP's")
+    # add static dependency preview
+    static_dep_display_widget = ScrollableTextWidget(result_notebook)
+    with open(
+            execution_configuration_obj.value_dict["working_copy_path"] + "/static_dependencies.txt", "r") as f:
+        static_dep_display_widget.set_text(f.read())
+    result_notebook.add(static_dep_display_widget.frame, text="Static DEP's")
     # add instrumented LLVM IR preview
     instrumented_llvm_ir_display_widget = ScrollableTextWidget(result_notebook)
     with open(


### PR DESCRIPTION
Adds a preview tab to show static and dynamic dependencies.

Before merge:
![Bildschirmfoto vom 2023-05-02 09-52-28](https://user-images.githubusercontent.com/26957074/235610525-4b38f418-1184-499c-8177-3ce187194d94.png)

After merge:

![Bildschirmfoto vom 2023-05-02 09-53-09](https://user-images.githubusercontent.com/26957074/235610558-150d24f0-8de5-4b3f-b623-07de88257550.png)
