### PR TITLE
fix: allow restoring of PET Graph via jsonpickle

### DIFF
--- a/discopop_explorer/parser.py
+++ b/discopop_explorer/parser.py
@@ -35,7 +35,7 @@ class DependenceItem(object):
 
 
 # TODO move this class to a better place, we need it not only for parsing
-@dataclass(frozen=True)
+@dataclass
 class LoopData(object):
     line_id: str  # file_id:line_nr
     total_iteration_count: int


### PR DESCRIPTION
@goerlibe 
Hi,
this PR is required so that the exported PET Graph can be restored.
If the `frozen` property is crucial, please revert the change and let me know.
In the mean time, i will merge this PR.