### PR TITLE
Fix(loading of dumped detection result): lxml.objectifiy.StringElement -> str

### DIFF
--- a/discopop_explorer/PETGraphX.py
+++ b/discopop_explorer/PETGraphX.py
@@ -513,7 +513,7 @@ def parse_cu(node: ObjectifiedElement) -> Node:
                 for v in getattr(node.globalVariables, "global")
             ]
         if hasattr(node, "BasicBlockID"):
-            n.basic_block_id = getattr(node, "BasicBlockID")
+            n.basic_block_id = getattr(node, "BasicBlockID").text
         if hasattr(node, "returnInstructions"):
             n.return_instructions_count = int(getattr(node, "returnInstructions").get("count"))
         if hasattr(node.callsNode, "nodeCalled"):


### PR DESCRIPTION
This issue prevented detection result objects from being restored from the dumped json file, if a non-empty basic block id was assigned to any node.