### PR TITLE
Ci improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install --upgrade pip
-          python -m pip install -r discopop_explorer/requirements.txt
-          python -m pip install -r discopop_profiler/requirements.txt
-          python -m pip install -r discopop_library/requirements.txt
-          python -m pip install mypy data-science-types black
+          pip install -r discopop_explorer/requirements.txt
+          pip install -r discopop_profiler/requirements.txt
+          pip install -r discopop_library/requirements.txt
+          pip install mypy data-science-types black
 
       - name: Python Unit-tests
         run: python -m unittest -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
+          pip install --upgrade pip
           python -m pip install -r discopop_explorer/requirements.txt
           python -m pip install -r discopop_profiler/requirements.txt
           python -m pip install -r discopop_library/requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     name: Execute CI Tests
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Check all files for DiscoPoP License tag"
         run: |
@@ -56,7 +56,7 @@ jobs:
           [ -z "$ERROR" ] || exit 1
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.8
 


### PR DESCRIPTION
ideas to speedup and improve ci pipeline:
- [x] update actions to newer versions
- [ ] remove "CI Tests Successful" job?
- [x] simplify setup commands 
  -  update pip
  - install testing tools
  - install discopop
  - 2nd and 3rd step can be combined `pip install .[dev]`
  - get rid of multiple requirements.txt and do a proper `pip freeze` of known working versions (compare e.g. [1](https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/) and [2](https://stackoverflow.com/a/33685899))
- [ ] disable profiler tests or only run them if changes were made to the respective directories
- [ ] can we parallelize black, mypy, pytest, license file checks?
- [ ] caching to keep python environment, i.e. pip installed libraries
- [ ] add more static checks (stronger mypy, pylint, ...)
- [ ] start writing tests to notice breaking changes