### PR TITLE
Feat/library/config provider

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,24 @@ add_subdirectory(rtlib)
 
 add_subdirectory(scripts)
 
+##### DEPRECATED #####
+# save build configuration to build/build_config.txt
+file(REMOVE "${DiscoPoP_BINARY_DIR}/build_config.txt")
+file(TOUCH "${DiscoPoP_BINARY_DIR}/build_config.txt")
+file(APPEND "${DiscoPoP_BINARY_DIR}/build_config.txt" "DP_BUILD=${DiscoPoP_BINARY_DIR}\n")
+file(APPEND "${DiscoPoP_BINARY_DIR}/build_config.txt" "DP_SOURCE=${DiscoPoP_SOURCE_DIR}\n")
+file(APPEND "${DiscoPoP_BINARY_DIR}/build_config.txt" "LLVM_BIN_DIR=${LLVM_TOOLS_BINARY_DIR}\n")
+file(APPEND "${DiscoPoP_BINARY_DIR}/build_config.txt" "PYTHON_EXECUTABLE=${Python3_EXECUTABLE}\n")
+##### END OF DEPRECATED #####
+
+# save build_config.py to discopop_library/ConfigProvider/assets for easy accessibility and global use
+file(REMOVE "${DiscoPoP_SOURCE_DIR}/discopop_library/ConfigProvider/assets/build_config.py")
+file(TOUCH "${DiscoPoP_SOURCE_DIR}/discopop_library/ConfigProvider/assets/build_config.py")
+file(APPEND "${DiscoPoP_SOURCE_DIR}/discopop_library/ConfigProvider/assets/build_config.py" "DP_BUILD=\"${DiscoPoP_BINARY_DIR}\"\n")
+file(APPEND "${DiscoPoP_SOURCE_DIR}/discopop_library/ConfigProvider/assets/build_config.py" "DP_SOURCE=\"${DiscoPoP_SOURCE_DIR}\"\n")
+file(APPEND "${DiscoPoP_SOURCE_DIR}/discopop_library/ConfigProvider/assets/build_config.py" "LLVM_BIN_DIR=\"${LLVM_TOOLS_BINARY_DIR}\"\n")
+file(APPEND "${DiscoPoP_SOURCE_DIR}/discopop_library/ConfigProvider/assets/build_config.py" "PYTHON_EXECUTABLE=\"${Python3_EXECUTABLE}\"\n")
+
 # install DiscoPoP python modules
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
@@ -80,11 +98,3 @@ execute_process(
 if(${DP_INSTALLATION_EXIT_CODE})
     message(FATAL_ERROR "${DP_INSTALLATION_OUTPUT}")
 endif()
-
-# save build configuration to build/build_config.txt
-file(REMOVE "${DiscoPoP_BINARY_DIR}/build_config.txt")
-file(TOUCH "${DiscoPoP_BINARY_DIR}/build_config.txt")
-file(APPEND "${DiscoPoP_BINARY_DIR}/build_config.txt" "DP_BUILD=${DiscoPoP_BINARY_DIR}\n")
-file(APPEND "${DiscoPoP_BINARY_DIR}/build_config.txt" "DP_SOURCE=${DiscoPoP_SOURCE_DIR}\n")
-file(APPEND "${DiscoPoP_BINARY_DIR}/build_config.txt" "LLVM_BIN_DIR=${LLVM_TOOLS_BINARY_DIR}\n")
-file(APPEND "${DiscoPoP_BINARY_DIR}/build_config.txt" "PYTHON_EXECUTABLE=${Python3_EXECUTABLE}\n")

--- a/discopop_library/ConfigProvider/ConfigProviderArguments.py
+++ b/discopop_library/ConfigProvider/ConfigProviderArguments.py
@@ -1,0 +1,26 @@
+# This file is part of the DiscoPoP software (http://www.discopop.tu-darmstadt.de)
+#
+# Copyright (c) 2020, Technische Universitaet Darmstadt, Germany
+#
+# This software may be modified and distributed under the terms of
+# the 3-Clause BSD License.  See the LICENSE file in the package base
+# directory for details.
+from dataclasses import dataclass
+
+
+@dataclass
+class ConfigProviderArguments(object):
+    """Container Class for the arguments passed to the discopop_config_provider"""
+
+    return_dp_build_dir: bool
+    return_dp_source_dir: bool
+    return_llvm_bin_dir: bool
+
+    def __post_init__(self):
+        self.__validate()
+
+    def __validate(self):
+        pass
+
+    def __str__(self):
+        return str(self.__dict__)

--- a/discopop_library/ConfigProvider/__main__.py
+++ b/discopop_library/ConfigProvider/__main__.py
@@ -1,0 +1,49 @@
+# This file is part of the DiscoPoP software (http://www.discopop.tu-darmstadt.de)
+#
+# Copyright (c) 2020, Technische Universitaet Darmstadt, Germany
+#
+# This software may be modified and distributed under the terms of
+# the 3-Clause BSD License.  See the LICENSE file in the package base
+# directory for details.
+
+from argparse import ArgumentParser
+from discopop_library.ConfigProvider.ConfigProviderArguments import ConfigProviderArguments
+from discopop_library.ConfigProvider.config_provider import run
+
+
+def parse_args() -> ConfigProviderArguments:
+    """Parse the arguments passed to the discopop_config_provider"""
+    parser = ArgumentParser(description="DiscoPoP Config Provider")
+    # all flags that are not considered stable should be added to the experimental_parser
+    experimental_parser = parser.add_argument_group(
+        "EXPERIMENTAL",
+        "Arguments for experimental features. Experimental arguments may or may not be removed or changed in the future.",
+    )
+
+    # fmt: off
+    parser.add_argument("-b", "--dp-build-dir", action="store_true",
+                        help="Return the path to the DiscoPoP build directory")
+    parser.add_argument("-s", "--dp-source-dir", action="store_true",
+                        help="Return the path to the DiscoPoP source directory")
+    parser.add_argument("--llvm-bin-dir", action="store_true",
+                        help="Return the path to the LLVM bin directory")
+    # EXPERIMENTAL FLAGS:
+    # fmt: on
+
+    arguments = parser.parse_args()
+
+    return ConfigProviderArguments(
+        return_dp_build_dir=arguments.dp_build_dir,
+        return_dp_source_dir=arguments.dp_source_dir,
+        return_llvm_bin_dir=arguments.llvm_bin_dir,
+    )
+
+
+def main() -> str:
+    arguments = parse_args()
+    retval = run(arguments)
+    return retval
+
+
+if __name__ == "__main__":
+    main()

--- a/discopop_library/ConfigProvider/assets/.gitignore
+++ b/discopop_library/ConfigProvider/assets/.gitignore
@@ -1,0 +1,9 @@
+# This file is part of the DiscoPoP software (http://www.discopop.tu-darmstadt.de)
+#
+# Copyright (c) 2020, Technische Universitaet Darmstadt, Germany
+#
+# This software may be modified and distributed under the terms of
+# the 3-Clause BSD License.  See the LICENSE file in the package base
+# directory for details.
+
+build_config.py

--- a/discopop_library/ConfigProvider/config_provider.py
+++ b/discopop_library/ConfigProvider/config_provider.py
@@ -1,0 +1,24 @@
+# This file is part of the DiscoPoP software (http://www.discopop.tu-darmstadt.de)
+#
+# Copyright (c) 2020, Technische Universitaet Darmstadt, Germany
+#
+# This software may be modified and distributed under the terms of
+# the 3-Clause BSD License.  See the LICENSE file in the package base
+# directory for details.
+
+from typing import cast
+from discopop_library.ConfigProvider.ConfigProviderArguments import ConfigProviderArguments
+from discopop_library.ConfigProvider.assets.build_config import DP_BUILD, DP_SOURCE, LLVM_BIN_DIR  # type: ignore
+
+
+def run(arguments: ConfigProviderArguments) -> str:
+    """Returns the contents of the written build_config.txt"""
+
+    if arguments.return_dp_build_dir:
+        return cast(str, DP_BUILD)  # type: ignore
+    elif arguments.return_dp_source_dir:
+        return cast(str, DP_SOURCE)  # type: ignore
+    elif arguments.return_llvm_bin_dir:
+        return cast(str, LLVM_BIN_DIR)  # type: ignore
+    else:
+        raise ValueError("No valid operation for execution configuration: \n" + str(arguments))

--- a/discopop_library/PatchGenerator/__main__.py
+++ b/discopop_library/PatchGenerator/__main__.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 from discopop_library.PatchGenerator.PatchGeneratorArguments import PatchGeneratorArguments
 from discopop_library.PatchGenerator.patch_generator import run
+from discopop_library.ConfigProvider.config_provider import run as run_config_provider
+from discopop_library.ConfigProvider.ConfigProviderArguments import ConfigProviderArguments
 
 
 def parse_args() -> PatchGeneratorArguments:
@@ -19,44 +21,41 @@ def parse_args() -> PatchGeneratorArguments:
     # all flags that are not considered stable should be added to the experimental_parser
     experimental_parser = parser.add_argument_group(
         "EXPERIMENTAL",
-        "Arguments for the task pattern detector and other experimental features. These flags are considered EXPERIMENTAL and they may or may not be removed or changed in the near future.",
+        "Arguments marked as experimental features. These flags may or may not be removed or changed in the future.",
     )
 
     # fmt: off
     parser.add_argument("--verbose", action="store_true",
         help="Enable verbose output.")
-    parser.add_argument(
-        "--dp-build-path", type=str, required=True,
-        help="Path to DiscoPoP build folder"
-    )
     # EXPERIMENTAL FLAGS:
     # fmt: on
 
     arguments = parser.parse_args()
 
-    # determine CC and CXX
-    with open(os.path.join(arguments.dp_build_path, "build_config.txt"), "r") as f:
-        for line in f.readlines():
-            if line.startswith("LLVM_BIN_DIR="):
-                line = line.replace("\n", "")
-                llvm_bin_dir = line[len("LLVM_BIN_DIR=") :]
-                # determine CC
-                if os.path.exists(os.path.join(llvm_bin_dir, "clang")):
-                    arguments.cc = os.path.join(llvm_bin_dir, "clang")
-                elif os.path.exists(os.path.join(llvm_bin_dir, "clang-11")):
-                    arguments.cc = os.path.join(llvm_bin_dir, "clang-11")
-                else:
-                    raise ValueError("Could not determine CC from discopop build path: ", arguments.dp_build_path)
+    # determine DP build path
+    arguments.dp_build_path = run_config_provider(
+        ConfigProviderArguments(return_dp_build_dir=True, return_dp_source_dir=False, return_llvm_bin_dir=False)
+    )
 
-                # determine CXX
-                if os.path.exists(os.path.join(llvm_bin_dir, "clang++")):
-                    arguments.cxx = os.path.join(llvm_bin_dir, "clang++")
-                elif os.path.exists(os.path.join(llvm_bin_dir, "clang++-11")):
-                    arguments.cxx = os.path.join(llvm_bin_dir, "clang++-11")
-                else:
-                    raise ValueError("Could not determine CXX from discopop build path: ", arguments.dp_build_path)
+    # determine LLVM_BIN_DIR
+    llvm_bin_dir = run_config_provider(
+        ConfigProviderArguments(return_dp_build_dir=False, return_dp_source_dir=False, return_llvm_bin_dir=True)
+    )
+    # determine CC
+    if os.path.exists(os.path.join(llvm_bin_dir, "clang")):
+        arguments.cc = os.path.join(llvm_bin_dir, "clang")
+    elif os.path.exists(os.path.join(llvm_bin_dir, "clang-11")):
+        arguments.cc = os.path.join(llvm_bin_dir, "clang-11")
+    else:
+        raise ValueError("Could not determine CC from LLVM_BIN_DIR: ", llvm_bin_dir)
 
-                break
+    # determine CXX
+    if os.path.exists(os.path.join(llvm_bin_dir, "clang++")):
+        arguments.cxx = os.path.join(llvm_bin_dir, "clang++")
+    elif os.path.exists(os.path.join(llvm_bin_dir, "clang++-11")):
+        arguments.cxx = os.path.join(llvm_bin_dir, "clang++-11")
+    else:
+        raise ValueError("Could not determine CXX from LLVM_BIN_DIR: ", llvm_bin_dir)
 
     return PatchGeneratorArguments(
         verbose=arguments.verbose, discopop_build_path=arguments.dp_build_path, CC=arguments.cc, CXX=arguments.cxx

--- a/mypy.ini
+++ b/mypy.ini
@@ -14,6 +14,9 @@
 # select files to check
 files = discopop_explorer, discopop_library, discopop_profiler, discopop_wizard
 
+# select files to ignore
+exclude = discopop_library/ConfigProvider/assets/build_config.py
+
 # helps to catch typos in this file
 warn_unused_configs = True
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
             "discopop_optimizer=discopop_library.discopop_optimizer.__main__:main",
             "discopop_patch_generator=discopop_library.PatchGenerator.__main__:main",
             "discopop_patch_applicator=discopop_library.PatchApplicator.__main__:main",
+            "discopop_config_provider=discopop_library.ConfigProvider.__main__:main",
         ]
     },
     zip_safe=True,


### PR DESCRIPTION
- adds a utility to access the `build_config` globally
- removes the required `--dp-build-dir` argument from `discopop_patch_generator`
- marks `build/build_config.txt` as deprecated