### PR TITLE
Feat/install/venv/compiler wrappers

### DIFF
--- a/.github/workflows/Dockerfile_ci
+++ b/.github/workflows/Dockerfile_ci
@@ -13,7 +13,7 @@ WORKDIR /usr/local/ci
 ADD ../.. /usr/local/ci/discopop
 
 # build discopop
-RUN cmake -S discopop -B discopop/build -DCMAKE_BUILD_TYPE=Debug -DLLVM_DIST_PATH=/usr/local/ci/software/llvm-11.1.0 -DUSE_VENV=/usr/local/ci/venv -DDP_CALLTREE_PROFILING=1
+RUN cmake -S discopop -B discopop/build -DCMAKE_BUILD_TYPE=Debug -DLLVM_DIST_PATH=/usr/local/ci/software/llvm-11.1.0 -DUSE_VENV=/usr/local/ci/venv -DDP_CALLTREE_PROFILING=1 -DDP_BUILD_UNITTESTS=1
 RUN make --directory=discopop/build -j
 RUN make --directory=discopop/build install_python_modules
 

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -18,24 +18,38 @@ configure_file(MPI_CC_wrapper.sh MPI_CC_wrapper.sh COPYONLY)
 configure_file(MPI_CXX_wrapper.sh MPI_CXX_wrapper.sh COPYONLY)
 configure_file(MPI_LINKER_wrapper.sh MPI_LINKER_wrapper.sh COPYONLY)
 
+# setup DiscoPoP venv
+if(NOT ${USE_VENV} STREQUAL "")
+    message(STATUS "Setting up existing python venv: ${USE_VENV}")
+    set(Python3_VENV_EXECUTABLE ${USE_VENV}/bin/python3)
+    set(Python3_VENV_BIN_PATH ${USE_VENV}/bin)
+else()
+    message(STATUS "Setting up default DiscoPoP python venv: ${DiscoPoP_SOURCE_DIR}/venv")
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -m venv ${DiscoPoP_SOURCE_DIR}/venv
+    )
+    set(Python3_VENV_EXECUTABLE ${DiscoPoP_SOURCE_DIR}/venv/bin/python3)
+    set(Python3_VENV_BIN_PATH ${DiscoPoP_SOURCE_DIR}/venv/bin)
+endif()
+
 if(NOT ${IS_DEB_INSTALL} STREQUAL "")
     # create symlinks to files
     message(STATUS "performing installation from .deb package")
 else()
     # create symlinks to files
     set(DP_LOCAL_BIN_DIR "$ENV{HOME}/.local/bin")
-    if(EXISTS ${DP_LOCAL_BIN_DIR})
-        execute_process(COMMAND rm -f ${DP_LOCAL_BIN_DIR}/discopop_cc)
-        message(STATUS "Creating symlink ${DP_LOCAL_BIN_DIR}/discopop_cc to ${CMAKE_CURRENT_BINARY_DIR}/CC_wrapper.sh")
-        execute_process(COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/CC_wrapper.sh ${DP_LOCAL_BIN_DIR}/discopop_cc)
+    if(EXISTS ${Python3_VENV_BIN_PATH})
+        execute_process(COMMAND rm -f ${Python3_VENV_BIN_PATH}/discopop_cc)
+        message(STATUS "Creating symlink ${Python3_VENV_BIN_PATH}/discopop_cc to ${CMAKE_CURRENT_BINARY_DIR}/CC_wrapper.sh")
+        execute_process(COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/CC_wrapper.sh ${Python3_VENV_BIN_PATH}/discopop_cc)
 
-        execute_process(COMMAND rm -f ${DP_LOCAL_BIN_DIR}/discopop_cxx)
-        message(STATUS "Creating symlink ${DP_LOCAL_BIN_DIR}/discopop_cxx to ${CMAKE_CURRENT_BINARY_DIR}/CXX_wrapper.sh")
-        execute_process(COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/CXX_wrapper.sh ${DP_LOCAL_BIN_DIR}/discopop_cxx)
+        execute_process(COMMAND rm -f ${Python3_VENV_BIN_PATH}/discopop_cxx)
+        message(STATUS "Creating symlink ${Python3_VENV_BIN_PATH}/discopop_cxx to ${CMAKE_CURRENT_BINARY_DIR}/CXX_wrapper.sh")
+        execute_process(COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/CXX_wrapper.sh ${Python3_VENV_BIN_PATH}/discopop_cxx)
 
-        execute_process(COMMAND rm -f ${DP_LOCAL_BIN_DIR}/discopop_cmake)
-        message(STATUS "Creating symlink ${DP_LOCAL_BIN_DIR}/discopop_cmake to ${CMAKE_CURRENT_BINARY_DIR}/CMAKE_wrapper.sh")
-        execute_process(COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/CMAKE_wrapper.sh ${DP_LOCAL_BIN_DIR}/discopop_cmake)
+        execute_process(COMMAND rm -f ${Python3_VENV_BIN_PATH}/discopop_cmake)
+        message(STATUS "Creating symlink ${Python3_VENV_BIN_PATH}/discopop_cmake to ${CMAKE_CURRENT_BINARY_DIR}/CMAKE_wrapper.sh")
+        execute_process(COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/CMAKE_wrapper.sh ${Python3_VENV_BIN_PATH}/discopop_cmake)
     else()
         message(WARNING "Creation of symlinks discopop_cc to ${CMAKE_CURRENT_BINARY_DIR}/CC_wrapper.sh not possible. Please create it manually.")
         message(WARNING "Creation of symlinks discopop_cxx to ${CMAKE_CURRENT_BINARY_DIR}/CXX_wrapper.sh not possible. Please create it manually.")


### PR DESCRIPTION
Create softlinks `discopop_cc`, `discopop_cxx`, and `discopop_cmake` to compiler-wrapper scripts in `venv` during build