### PR TITLE
feat: add LLVM 22 support to profiler

### DIFF
--- a/profiler/DiscoPoP/RegisterPass.cpp
+++ b/profiler/DiscoPoP/RegisterPass.cpp
@@ -40,7 +40,11 @@ ModulePass *createDiscoPoPPass() {
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Passes/PassBuilder.h"
+#if LLVM_VERSION_MAJOR >= 22
+#include "llvm/Plugins/PassPlugin.h"
+#else
 #include "llvm/Passes/PassPlugin.h"
+#endif
 #include "llvm/Support/raw_ostream.h"
 #include <iostream>
 #include "DiscoPoP.hpp"

--- a/profiler/DiscoPoP/dp_reduction/insert_functions.cpp
+++ b/profiler/DiscoPoP/dp_reduction/insert_functions.cpp
@@ -50,7 +50,11 @@ void DiscoPoP::dp_reduction_insert_functions() {
     args.push_back(llvm::ConstantInt::get(llvm::Type::getInt32Ty(*ctx_), loop_info.loop_id));
     args.push_back(llvm::ConstantInt::get(llvm::Type::getInt32Ty(*ctx_), 0));  // instruction id will be replaced after assigning unique
 
+#if LLVM_VERSION_MAJOR >= 22
+    llvm::CallInst::Create(incr_loop_counter_callee, args, "", loop_info.first_body_instr_->getIterator());
+#else
     llvm::CallInst::Create(incr_loop_counter_callee, args, "", loop_info.first_body_instr_);
+#endif
     loop_metadata_file << loop_info.file_id_ << " ";
     loop_metadata_file << loop_info.loop_id << " ";
     loop_metadata_file << loop_info.line_nr_ << "\n";

--- a/profiler/DiscoPoP/instrumentation/low_level/instrumentCalloc.cpp
+++ b/profiler/DiscoPoP/instrumentation/low_level/instrumentCalloc.cpp
@@ -21,7 +21,11 @@ void DiscoPoP::instrumentCalloc(CallBase *toInstrument) {
   // Determine correct placement for the call to __dp_new
   Instruction *nextInst = nullptr;
   if (isa<CallInst>(toInstrument)) {
+#if LLVM_VERSION_MAJOR >= 22
+    nextInst = toInstrument->getNextNode();
+#else
     nextInst = toInstrument->getNextNonDebugInstruction();
+#endif
   } else if (isa<InvokeInst>(toInstrument)) {
     // Invoke instructions are always located at the end of a basic block.
     // Invoke instructions may throw errors, in which case the successor is a
@@ -37,7 +41,11 @@ void DiscoPoP::instrumentCalloc(CallBase *toInstrument) {
   vector<Value *> args;
   args.push_back(ConstantInt::get(Int32, lid));
 
+#if LLVM_VERSION_MAJOR >= 22
+  Value *startAddr = PtrToIntInst::CreatePointerCast(toInstrument, Int64, "", nextInst->getIterator());
+#else
   Value *startAddr = PtrToIntInst::CreatePointerCast(toInstrument, Int64, "", nextInst);
+#endif
   Value *endAddr = startAddr;
   Value *numBytes = IRB.CreateMul(toInstrument->getArgOperand(0), toInstrument->getArgOperand(1));
 

--- a/profiler/DiscoPoP/instrumentation/low_level/instrumentDeleteOrFree.cpp
+++ b/profiler/DiscoPoP/instrumentation/low_level/instrumentDeleteOrFree.cpp
@@ -17,13 +17,22 @@ void DiscoPoP::instrumentDeleteOrFree(CallBase *toInstrument) {
   LID lid = getLID(toInstrument, fileID);
   if (lid == 0)
     return;
+#if LLVM_VERSION_MAJOR >= 22
+  IRBuilder<> IRB(toInstrument->getNextNode());
+#else
   IRBuilder<> IRB(toInstrument->getNextNonDebugInstruction());
+#endif
 
   vector<Value *> args;
   args.push_back(ConstantInt::get(Int32, lid));
 
+#if LLVM_VERSION_MAJOR >= 22
+  Value *startAddr =
+      PtrToIntInst::CreatePointerCast(toInstrument->getArgOperand(0), Int64, "", toInstrument->getNextNode()->getIterator());
+#else
   Value *startAddr =
       PtrToIntInst::CreatePointerCast(toInstrument->getArgOperand(0), Int64, "", toInstrument->getNextNode());
+#endif
 
   args.push_back(startAddr);
 

--- a/profiler/DiscoPoP/instrumentation/low_level/instrumentLoad.cpp
+++ b/profiler/DiscoPoP/instrumentation/low_level/instrumentLoad.cpp
@@ -22,7 +22,11 @@ void DiscoPoP::instrumentLoad(LoadInst *toInstrument, int32_t llvm_ir_instructio
 
   args.push_back(ConstantInt::get(Int32, llvm_ir_instruction_id));
 
+#if LLVM_VERSION_MAJOR >= 22
+  Value *memAddr = PtrToIntInst::CreatePointerCast(toInstrument->getPointerOperand(), Int64, "", toInstrument->getIterator());
+#else
   Value *memAddr = PtrToIntInst::CreatePointerCast(toInstrument->getPointerOperand(), Int64, "", toInstrument);
+#endif
   args.push_back(memAddr);
 
   args.push_back(determineVariableName_dynamic(toInstrument, ""));
@@ -47,7 +51,11 @@ void DiscoPoP::instrumentLoad(LoadInst *toInstrument, int32_t llvm_ir_instructio
   args.push_back(currentAddrTracker);
   args.push_back(currentCount);
 #endif
+#if LLVM_VERSION_MAJOR >= 22
+  CallInst::Create(DpRead, args, "", toInstrument->getIterator());
+#else
   CallInst::Create(DpRead, args, "", toInstrument);
+#endif
 
 #ifdef SKIP_DUP_INSTR
   // Post instrumentation call
@@ -58,8 +66,14 @@ void DiscoPoP::instrumentLoad(LoadInst *toInstrument, int32_t llvm_ir_instructio
   StoreInst *countUpdate = new StoreInst::StoreInst(incCount, countTracker);
 
   // add updates after before
+#if LLVM_VERSION_MAJOR >= 22
+  addrUpdate->insertAfter(toInstrument->getIterator());
+  incCount->insertAfter(toInstrument->getIterator());
+  countUpdate->insertAfter(incCount->getIterator());
+#else
   addrUpdate->insertAfter(toInstrument);
   incCount->insertAfter(toInstrument);
   countUpdate->insertAfter(incCount);
+#endif
 #endif
 }

--- a/profiler/DiscoPoP/instrumentation/low_level/instrumentLoopEntry.cpp
+++ b/profiler/DiscoPoP/instrumentation/low_level/instrumentLoopEntry.cpp
@@ -34,7 +34,11 @@ void DiscoPoP::instrumentLoopEntry(BasicBlock *bb, int32_t id) {
       args.push_back(ConstantInt::get(Int32, lid));
       args.push_back(ConstantInt::get(Int32, id));
       args.push_back(ConstantInt::get(Int32, 0));  // instruction id will be replaced after the assignment of unique instruction ids
+#if LLVM_VERSION_MAJOR >= 22
+      CallInst::Create(DpLoopEntry, args, "", BI);
+#else
       CallInst::Create(DpLoopEntry, args, "", &*BI);
+#endif
       break;
     }
   }

--- a/profiler/DiscoPoP/instrumentation/low_level/instrumentLoopExit.cpp
+++ b/profiler/DiscoPoP/instrumentation/low_level/instrumentLoopExit.cpp
@@ -23,8 +23,13 @@ void DiscoPoP::instrumentLoopExit(BasicBlock *bb, int32_t id) {
       args.push_back(ConstantInt::get(Int32, lid));
       args.push_back(ConstantInt::get(Int32, id));
       args.push_back(ConstantInt::get(Int32, 0));  // instruction id will be replaced after the assignment of unique instruction ids
+#if LLVM_VERSION_MAJOR >= 22
+      CallInst::Create(DpLoopExit, args, "",
+                       currentBB->begin()); // always insert to the beiginning
+#else
       CallInst::Create(DpLoopExit, args, "",
                        &*currentBB->begin()); // always insert to the beiginning
+#endif
       break;
     }
   }

--- a/profiler/DiscoPoP/instrumentation/low_level/instrumentNewOrMalloc.cpp
+++ b/profiler/DiscoPoP/instrumentation/low_level/instrumentNewOrMalloc.cpp
@@ -21,7 +21,11 @@ void DiscoPoP::instrumentNewOrMalloc(CallBase *toInstrument) {
   // Determine correct placement for the call to __dp_new
   Instruction *nextInst = nullptr;
   if (isa<CallInst>(toInstrument)) {
+#if LLVM_VERSION_MAJOR >= 22
+    nextInst = toInstrument->getNextNode();
+#else
     nextInst = toInstrument->getNextNonDebugInstruction();
+#endif
   } else if (isa<InvokeInst>(toInstrument)) {
     // Invoke instructions are always located at the end of a basic block.
     // Invoke instructions may throw errors, in which case the successor is a
@@ -37,7 +41,11 @@ void DiscoPoP::instrumentNewOrMalloc(CallBase *toInstrument) {
   vector<Value *> args;
   args.push_back(ConstantInt::get(Int32, lid));
 
+#if LLVM_VERSION_MAJOR >= 22
+  Value *startAddr = PtrToIntInst::CreatePointerCast(toInstrument, Int64, "", nextInst->getIterator());
+#else
   Value *startAddr = PtrToIntInst::CreatePointerCast(toInstrument, Int64, "", nextInst);
+#endif
   Value *endAddr = startAddr;
   Value *numBytes = toInstrument->getArgOperand(0);
 

--- a/profiler/DiscoPoP/instrumentation/low_level/instrumentPosixMemalign.cpp
+++ b/profiler/DiscoPoP/instrumentation/low_level/instrumentPosixMemalign.cpp
@@ -21,7 +21,11 @@ void DiscoPoP::instrumentPosixMemalign(CallBase *toInstrument) {
   // Determine correct placement for the call to __dp_new
   Instruction *nextInst = nullptr;
   if (isa<CallInst>(toInstrument)) {
+#if LLVM_VERSION_MAJOR >= 22
+    nextInst = toInstrument->getNextNode();
+#else
     nextInst = toInstrument->getNextNonDebugInstruction();
+#endif
   } else if (isa<InvokeInst>(toInstrument)) {
     // Invoke instructions are always located at the end of a basic block.
     // Invoke instructions may throw errors, in which case the successor is a
@@ -37,7 +41,11 @@ void DiscoPoP::instrumentPosixMemalign(CallBase *toInstrument) {
   vector<Value *> args;
   args.push_back(ConstantInt::get(Int32, lid));
 
+#if LLVM_VERSION_MAJOR >= 22
+  Value *startAddr = PtrToIntInst::CreatePointerCast(toInstrument->getArgOperand(0), Int64, "", nextInst->getIterator());
+#else
   Value *startAddr = PtrToIntInst::CreatePointerCast(toInstrument->getArgOperand(0), Int64, "", nextInst);
+#endif
   Value *endAddr = startAddr;
   Value *numBytes = toInstrument->getArgOperand(2);
 

--- a/profiler/DiscoPoP/instrumentation/low_level/instrumentRealloc.cpp
+++ b/profiler/DiscoPoP/instrumentation/low_level/instrumentRealloc.cpp
@@ -21,7 +21,11 @@ void DiscoPoP::instrumentRealloc(CallBase *toInstrument) {
   // Determine correct placement for the call to __dp_new
   Instruction *nextInst = nullptr;
   if (isa<CallInst>(toInstrument)) {
+#if LLVM_VERSION_MAJOR >= 22
+    nextInst = toInstrument->getNextNode();
+#else
     nextInst = toInstrument->getNextNonDebugInstruction();
+#endif
   } else if (isa<InvokeInst>(toInstrument)) {
     // Invoke instructions are always located at the end of a basic block.
     // Invoke instructions may throw errors, in which case the successor is a
@@ -37,8 +41,13 @@ void DiscoPoP::instrumentRealloc(CallBase *toInstrument) {
 
   // deallocate
   args.push_back(ConstantInt::get(Int32, lid));
+#if LLVM_VERSION_MAJOR >= 22
+  Value *startAddr =
+      PtrToIntInst::CreatePointerCast(toInstrument->getArgOperand(0), Int64, "", toInstrument->getNextNode()->getIterator());
+#else
   Value *startAddr =
       PtrToIntInst::CreatePointerCast(toInstrument->getArgOperand(0), Int64, "", toInstrument->getNextNode());
+#endif
   args.push_back(startAddr);
   IRB.CreateCall(DpDelete, args, "");
   args.clear();

--- a/profiler/DiscoPoP/instrumentation/low_level/instrumentStore.cpp
+++ b/profiler/DiscoPoP/instrumentation/low_level/instrumentStore.cpp
@@ -21,7 +21,11 @@ void DiscoPoP::instrumentStore(StoreInst *toInstrument, int32_t llvm_ir_instruct
   vector<Value *> args;
   args.push_back(ConstantInt::get(Int32, llvm_ir_instruction_id));
 
+#if LLVM_VERSION_MAJOR >= 22
+  Value *memAddr = PtrToIntInst::CreatePointerCast(toInstrument->getPointerOperand(), Int64, "", toInstrument->getIterator());
+#else
   Value *memAddr = PtrToIntInst::CreatePointerCast(toInstrument->getPointerOperand(), Int64, "", toInstrument);
+#endif
   args.push_back(memAddr);
 
   args.push_back(determineVariableName_dynamic(toInstrument, ""));
@@ -47,7 +51,11 @@ void DiscoPoP::instrumentStore(StoreInst *toInstrument, int32_t llvm_ir_instruct
   args.push_back(currentCount);
 #endif
 
+#if LLVM_VERSION_MAJOR >= 22
+  CallInst::Create(DpWrite, args, "", toInstrument->getIterator());
+#else
   CallInst::Create(DpWrite, args, "", toInstrument);
+#endif
 
 #ifdef SKIP_DUP_INSTR
   // Post instrumentation call
@@ -58,8 +66,14 @@ void DiscoPoP::instrumentStore(StoreInst *toInstrument, int32_t llvm_ir_instruct
   StoreInst *countUpdate = new StoreInst::StoreInst(incCount, countTracker);
 
   // add updates after before
+#if LLVM_VERSION_MAJOR >= 22
+  addrUpdate->insertAfter(toInstrument->getIterator());
+  incCount->insertAfter(toInstrument->getIterator());
+  countUpdate->insertAfter(incCount->getIterator());
+#else
   addrUpdate->insertAfter(toInstrument);
   incCount->insertAfter(toInstrument);
   countUpdate->insertAfter(incCount);
+#endif
 #endif
 }

--- a/profiler/DiscoPoP/llvm_hooks/doFinalization.cpp
+++ b/profiler/DiscoPoP/llvm_hooks/doFinalization.cpp
@@ -63,7 +63,11 @@ bool DiscoPoP::doFinalization(Module &M) {
             if (Fun->getName() == "__dp_finalize") {
               IRBuilder<> builder(call_inst);
               Value *V = builder.CreateGlobalStringPtr(StringRef(bbDepString), ".dp_bb_deps");
+#if LLVM_VERSION_MAJOR >= 22
+              CallInst::Create(F.getParent()->getOrInsertFunction("__dp_add_bb_deps", Void, CharPtr), V, "", call_inst->getIterator());
+#else
               CallInst::Create(F.getParent()->getOrInsertFunction("__dp_add_bb_deps", Void, CharPtr), V, "", call_inst);
+#endif
             }
           }
         }

--- a/profiler/DiscoPoP/llvm_hooks/runOnFunction.cpp
+++ b/profiler/DiscoPoP/llvm_hooks/runOnFunction.cpp
@@ -371,9 +371,17 @@ bool DiscoPoP::runOnFunction(Function &F, ModuleAnalysisManager &MAM) {
       // Insert call to reportbb
       Instruction *insertionPoint = pair.first->getTerminator();
       if (isa<ReturnInst>(pair.first->getTerminator())) {
+#if LLVM_VERSION_MAJOR >= 22
+        insertionPoint = insertionPoint->getPrevNode();
+#else
         insertionPoint = insertionPoint->getPrevNonDebugInstruction();
+#endif
       }
+#if LLVM_VERSION_MAJOR >= 22
+      CallInst::Create(ReportBB, ConstantInt::get(Int32, bbDepCount), "", insertionPoint->getIterator());
+#else
       CallInst::Create(ReportBB, ConstantInt::get(Int32, bbDepCount), "", insertionPoint);
+#endif
 
       // ---- Insert deps into string ----
       if (bbDepCount)
@@ -393,17 +401,32 @@ bool DiscoPoP::runOnFunction(Function &F, ModuleAnalysisManager &MAM) {
     // Add observation of in-order execution of pairs of basic blocks
     for (auto pair1 : conditionalBBPairDepMap) {
       // Alloca and init semaphore var for BB
+#if LLVM_VERSION_MAJOR >= 22
+      auto AI = new AllocaInst(Int32, 0, "__dp_bb", F.getEntryBlock().getFirstNonPHI()->getNextNode()->getIterator());
+      new StoreInst(ConstantInt::get(Int32, 0), AI, false, AI->getNextNode()->getIterator());
+#else
       auto AI = new AllocaInst(Int32, 0, "__dp_bb", F.getEntryBlock().getFirstNonPHI()->getNextNonDebugInstruction());
       new StoreInst(ConstantInt::get(Int32, 0), AI, false, AI->getNextNonDebugInstruction());
+#endif
 
       for (auto pair2 : pair1.second) {
         // Insert check for semaphore
         Instruction *insertionPoint = pair2.first->getTerminator();
-        if (isa<ReturnInst>(pair2.first->getTerminator()))
+        if (isa<ReturnInst>(pair2.first->getTerminator())) {
+#if LLVM_VERSION_MAJOR >= 22
+          insertionPoint = insertionPoint->getPrevNode();
+#else
           insertionPoint = insertionPoint->getPrevNonDebugInstruction();
+#endif
+        }
 
+#if LLVM_VERSION_MAJOR >= 22
+        auto LI = new LoadInst(Int32, AI, Twine(""), false, insertionPoint->getIterator());
+        CallInst::Create(ReportBBPair, ArrayRef<Value *>({LI, ConstantInt::get(Int32, bbDepCount)}), "", insertionPoint->getIterator());
+#else
         auto LI = new LoadInst(Int32, AI, Twine(""), false, insertionPoint);
         CallInst::Create(ReportBBPair, ArrayRef<Value *>({LI, ConstantInt::get(Int32, bbDepCount)}), "", insertionPoint);
+#endif
 
         // ---- Insert deps into string ----
         if (bbDepCount)
@@ -421,7 +444,11 @@ bool DiscoPoP::runOnFunction(Function &F, ModuleAnalysisManager &MAM) {
         ++bbDepCount;
       }
       // Insert semaphore update to true
+#if LLVM_VERSION_MAJOR >= 22
+      new StoreInst(ConstantInt::get(Int32, 1), AI, false, pair1.first->getTerminator()->getIterator());
+#else
       new StoreInst(ConstantInt::get(Int32, 1), AI, false, pair1.first->getTerminator());
+#endif
     }
 
     if (DumpToDot) {


### PR DESCRIPTION
Establish LLVM 22 compatibility by addressing API breaking changes:

1. Fix header path: llvm/Passes/PassPlugin.h → llvm/Plugins/PassPlugin.h
   - Added version guard (LLVM_VERSION_MAJOR >= 22)
   - Changed in RegisterPass.cpp

2. Replace removed methods with LLVM 22 equivalents:
   - getNextNonDebugInstruction() → getNextNode()
   - getPrevNonDebugInstruction() → getPrevNode()
   - In LLVM 22, debug info is no longer in instruction stream (DbgRecord), so getNextNode() is semantically equivalent
   - Affected 5 instrument files and runOnFunction.cpp

3. Fix deprecated InsertPosition API:
   - CallInst::Create, PtrToIntInst::CreatePointerCast with Instruction* → use Instruction->getIterator()
   - AllocaInst/StoreInst/LoadInst constructors taking Instruction* → use getIterator()
   - insertAfter(Instruction*) → use getIterator()
   - Affected 8 files across instrumentation, llvm_hooks, and dp_reduction

All changes maintain backward compatibility with LLVM 19-21 using #if LLVM_VERSION_MAJOR >= 22 guards.

Build verified: LLVMDiscoPoP.so (712K) and libDiscoPoP_RT.a (1.0M) successfully compiled with LLVM 22.1.6