### PR TITLE
fix: skip -lpthread on macOS where pthread is part of libSystem

### DIFF
--- a/hotspot_detection/scripts/CC_wrapper.sh
+++ b/hotspot_detection/scripts/CC_wrapper.sh
@@ -20,4 +20,7 @@ if [ -z "$LLVM_CLANG" ]; then
     exit 1
 fi
 
-${LLVM_CLANG} "$@" -g -fno-discard-value-names -O0 -Xclang -load -Xclang ${LIBS_DIR}/LLVMHotspotDetection.so -Xclang -fpass-plugin=${LIBS_DIR}/LLVMHotspotDetection.so -Xlinker -L${LIBS_DIR} -Xlinker -lHotspotDetection_RT -Xlinker -lpthread -Xlinker -v
+# pthread is bundled into libSystem on macOS; only link explicitly on Linux
+PTHREAD_XLINKER_FLAGS=()
+[[ "$(uname)" != "Darwin" ]] && PTHREAD_XLINKER_FLAGS=(-Xlinker -lpthread)
+${LLVM_CLANG} "$@" -g -fno-discard-value-names -O0 -Xclang -load -Xclang ${LIBS_DIR}/LLVMHotspotDetection.so -Xclang -fpass-plugin=${LIBS_DIR}/LLVMHotspotDetection.so -Xlinker -L${LIBS_DIR} -Xlinker -lHotspotDetection_RT "${PTHREAD_XLINKER_FLAGS[@]}" -Xlinker -v

--- a/hotspot_detection/scripts/CXX_wrapper.sh
+++ b/hotspot_detection/scripts/CXX_wrapper.sh
@@ -20,4 +20,7 @@ if [ -z "$LLVM_CLANGPP" ]; then
     exit 1
 fi
 
-${LLVM_CLANGPP} "$@" -g -fno-discard-value-names -O0 -Xclang -load -Xclang ${LIBS_DIR}/LLVMHotspotDetection.so -Xclang -fpass-plugin=${LIBS_DIR}/LLVMHotspotDetection.so -Xlinker -L${LIBS_DIR} -Xlinker -lHotspotDetection_RT -Xlinker -lpthread -Xlinker -v
+# pthread is bundled into libSystem on macOS; only link explicitly on Linux
+PTHREAD_XLINKER_FLAGS=()
+[[ "$(uname)" != "Darwin" ]] && PTHREAD_XLINKER_FLAGS=(-Xlinker -lpthread)
+${LLVM_CLANGPP} "$@" -g -fno-discard-value-names -O0 -Xclang -load -Xclang ${LIBS_DIR}/LLVMHotspotDetection.so -Xclang -fpass-plugin=${LIBS_DIR}/LLVMHotspotDetection.so -Xlinker -L${LIBS_DIR} -Xlinker -lHotspotDetection_RT "${PTHREAD_XLINKER_FLAGS[@]}" -Xlinker -v

--- a/hotspot_detection/scripts/LINKER_wrapper.sh
+++ b/hotspot_detection/scripts/LINKER_wrapper.sh
@@ -18,4 +18,6 @@ if [ -z "$LLVM_CLANGPP" ]; then
     exit 1
 fi
 
-${LLVM_CLANGPP} "$@" -L${LIBS_DIR} -lHotspotDetection_RT -lpthread -fPIC -v
+# pthread is bundled into libSystem on macOS; only link explicitly on Linux
+PTHREAD_FLAG=""; [[ "$(uname)" != "Darwin" ]] && PTHREAD_FLAG="-lpthread"
+${LLVM_CLANGPP} "$@" -L${LIBS_DIR} -lHotspotDetection_RT ${PTHREAD_FLAG} -fPIC -v

--- a/profiler/scripts/CC_wrapper.sh
+++ b/profiler/scripts/CC_wrapper.sh
@@ -64,6 +64,9 @@ if [ -f "${PARENT_PATH}/LLVMDiscoPoP.dylib" ]; then
 else
     DISCOPOP_PLUGIN="${PARENT_PATH}/LLVMDiscoPoP.so"
 fi
-${LLVM_CLANG} "$@" -g -O0 -fno-discard-value-names -Xclang -load -Xclang ${DISCOPOP_PLUGIN} -Xclang -fpass-plugin=${DISCOPOP_PLUGIN} -fPIC -Xlinker -L${PARENT_PATH} -Xlinker -lDiscoPoP_RT -Xlinker -lpthread -Xlinker -v -Xlinker -lstdc++
+# pthread is bundled into libSystem on macOS; only link explicitly on Linux
+PTHREAD_XLINKER_FLAGS=()
+[[ "$(uname)" != "Darwin" ]] && PTHREAD_XLINKER_FLAGS=(-Xlinker -lpthread)
+${LLVM_CLANG} "$@" -g -O0 -fno-discard-value-names -Xclang -load -Xclang ${DISCOPOP_PLUGIN} -Xclang -fpass-plugin=${DISCOPOP_PLUGIN} -fPIC -Xlinker -L${PARENT_PATH} -Xlinker -lDiscoPoP_RT "${PTHREAD_XLINKER_FLAGS[@]}" -Xlinker -v -Xlinker -lstdc++
 
 # WARNING: OUTPUT IS A .ll FILE, ENDING IS .o

--- a/profiler/scripts/CXX_wrapper.sh
+++ b/profiler/scripts/CXX_wrapper.sh
@@ -75,6 +75,9 @@ if [ -f "${PARENT_PATH}/LLVMDiscoPoP.dylib" ]; then
 else
     DISCOPOP_PLUGIN="${PARENT_PATH}/LLVMDiscoPoP.so"
 fi
-${LLVM_CLANGPP} "$@" -g -O0 -fno-discard-value-names -Xclang -load -Xclang ${DISCOPOP_PLUGIN} -Xclang -fpass-plugin=${DISCOPOP_PLUGIN} -fPIC -Xlinker -L${PARENT_PATH} -Xlinker -lDiscoPoP_RT -Xlinker -lpthread -Xlinker -v
+# pthread is bundled into libSystem on macOS; only link explicitly on Linux
+PTHREAD_XLINKER_FLAGS=()
+[[ "$(uname)" != "Darwin" ]] && PTHREAD_XLINKER_FLAGS=(-Xlinker -lpthread)
+${LLVM_CLANGPP} "$@" -g -O0 -fno-discard-value-names -Xclang -load -Xclang ${DISCOPOP_PLUGIN} -Xclang -fpass-plugin=${DISCOPOP_PLUGIN} -fPIC -Xlinker -L${PARENT_PATH} -Xlinker -lDiscoPoP_RT "${PTHREAD_XLINKER_FLAGS[@]}" -Xlinker -v
 
 # WARNING: OUTPUT IS A .ll FILE, ENDING IS .o

--- a/profiler/scripts/LINKER_wrapper.sh
+++ b/profiler/scripts/LINKER_wrapper.sh
@@ -43,4 +43,6 @@ fi
 
 # script will be located alongside LLVMDiscoPoP.so and libDiscoPoP_RT.a in the python venv/lib/../discopop-profiler.libs
 PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-${LLVM_CLANGPP} "$@" -L${PARENT_PATH} -lDiscoPoP_RT -lpthread -fPIC -v
+# pthread is bundled into libSystem on macOS; only link explicitly on Linux
+PTHREAD_FLAG=""; [[ "$(uname)" != "Darwin" ]] && PTHREAD_FLAG="-lpthread"
+${LLVM_CLANGPP} "$@" -L${PARENT_PATH} -lDiscoPoP_RT ${PTHREAD_FLAG} -fPIC -v

--- a/profiler/scripts/MPI_LINKER_wrapper.sh
+++ b/profiler/scripts/MPI_LINKER_wrapper.sh
@@ -49,4 +49,6 @@ MPI_INCLUDES="$(mpic++ -showme:link)"
 
 # script will be located alongside LLVMDiscoPoP.so and libDiscoPoP_RT.a in the python venv/lib/../discopop-profiler.libs
 PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-${LLVM_CLANGPP} ${MPI_INCLUDES} "$@" -L${PARENT_PATH} -lDiscoPoP_RT -lpthread -fPIC -v
+# pthread is bundled into libSystem on macOS; only link explicitly on Linux
+PTHREAD_FLAG=""; [[ "$(uname)" != "Darwin" ]] && PTHREAD_FLAG="-lpthread"
+${LLVM_CLANGPP} ${MPI_INCLUDES} "$@" -L${PARENT_PATH} -lDiscoPoP_RT ${PTHREAD_FLAG} -fPIC -v


### PR DESCRIPTION
On macOS, libpthread does not exist as a standalone library — pthread symbols are provided by libSystem. Passing -lpthread to the linker causes 'library not found' errors. Guard all wrapper scripts with a uname check so -lpthread is not passed on MacOS.