### PR TITLE
fix: add requests and termcolor to requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,5 @@ threadpoolctl==3.6.0
 tqdm==4.67.1
 typish==1.9.3
 plotille
+requests
+termcolor


### PR DESCRIPTION
### Description
When following the official installation guide and running the initial tests (`venv/bin/python -m unittest -v`), the pipeline immediately crashes with a `ModuleNotFoundError` for `requests` (and subsequently `termcolor`). 

Additionally, the official setup documentation currently lacks the explicit step to install the Python dependencies (e.g., `pip install -r requirements.txt` or `pip install -e .`), which exacerbates this issue for first-time setups.

### The Issue
The test suite and `discopop_explorer` import `update_notifier.py`, which relies on dependencies defined deep inside `tools/submodules/update_notifications/setup.py`. However, during a standard first-time setup from the repository root, these submodule dependencies are completely ignored and never provisioned.

### The Fix
To resolve the crash without risking merge conflicts or altering the isolated configuration inside `tools/submodules/update_notifications/setup.py`, I have simply duplicated the missing `requests` and `termcolor` libraries into the root `requirements.txt`. 

This ensures that a standard root-level installation correctly provisions the entire environment out of the box so the test suite can run successfully.

### Steps to Reproduce the Original Bug
1. Create a fresh Python virtual environment.
2. Follow the current setup documentation (which misses the pip install step).
3. Attempt to run the test suite: `venv/bin/python -m unittest -v`
4. Observe the crash: `ModuleNotFoundError: No module named 'requests'` and  `ModuleNotFoundError: No module named 'termcolor'`.

<img width="910" height="260" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/68b465ac-ba8e-4c13-8fbf-062a74ba1c37" />
<img width="902" height="406" alt="turn self_synte_inport inportsam, glabats, locals," src="https://github.com/user-attachments/assets/961edf69-72b1-45de-9dc6-2040ba9cc45b" />
