### PR TITLE
fix: avoid GUI/tkinter dependencies crashing discopop_explorer on headless servers

### DIFF
--- a/explorer/discopop_explorer/classes/PEGraph/PEGraphX.py
+++ b/explorer/discopop_explorer/classes/PEGraph/PEGraphX.py
@@ -44,8 +44,19 @@ from discopop_explorer.enums.DepType import DepType
 from discopop_explorer.enums.EdgeType import EdgeType
 from discopop_explorer.enums.NodeType import NodeType
 
-from discopop_gui.Extendables.Plottable import Plottable
-from discopop_gui.Visualizers.Base import Base as Visualizer
+try:
+    from discopop_gui.Extendables.Plottable import Plottable
+    from discopop_gui.Visualizers.Base import Base as Visualizer
+except (ImportError, ModuleNotFoundError):
+
+    class Plottable:  # type: ignore[no-redef]
+        def __init__(self, visualizer: object = None) -> None:
+            pass
+
+        def plottable(self) -> bool:
+            return False
+
+    Visualizer = object  # type: ignore[assignment, misc]
 
 from discopop_explorer.utilities.PEGraphConstruction.parser import readlineToCUIdMap, writelineToCUIdMap
 from discopop_explorer.utilities.PEGraphConstruction.classes.LoopData import LoopData

--- a/explorer/discopop_explorer/classes/TaskGraph/ContextTaskGraph.py
+++ b/explorer/discopop_explorer/classes/TaskGraph/ContextTaskGraph.py
@@ -66,8 +66,20 @@ from discopop_explorer.classes.TaskGraph.Contexts.IterationContext import (
 )
 from discopop_explorer.classes.TaskGraph.TGNode import TGNode
 from discopop_explorer.classes.TaskGraph.TaskGraph import TaskGraph
-from discopop_gui.Extendables.Plottable import Plottable
-from discopop_gui.Visualizers.Base import Base as Visualizer
+
+try:
+    from discopop_gui.Extendables.Plottable import Plottable
+    from discopop_gui.Visualizers.Base import Base as Visualizer
+except (ImportError, ModuleNotFoundError):
+
+    class Plottable:  # type: ignore[no-redef]
+        def __init__(self, visualizer: object = None) -> None:
+            pass
+
+        def plottable(self) -> bool:
+            return False
+
+    Visualizer = object  # type: ignore[assignment, misc]
 
 from termcolor import cprint
 import matplotlib.lines as mlines

--- a/explorer/discopop_explorer/classes/TaskGraph/TaskGraph.py
+++ b/explorer/discopop_explorer/classes/TaskGraph/TaskGraph.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import random
 import signal
 import logging
+import sys
 from typing import Any, Deque, Dict, List, Optional, Set, Tuple, Union, cast
 import warnings
 import networkx as nx  # type: ignore
@@ -73,9 +74,14 @@ from discopop_explorer.functions.PEGraph.traversal.parent import get_parent_func
 from discopop_explorer.functions.PEGraph.traversal.predecessors import direct_predecessors
 from discopop_explorer.functions.PEGraph.traversal.successors import direct_successors
 
-try:
-    matplotlib.use("TkAgg")
-except Exception:
+if os.environ.get("DISPLAY") or sys.platform in ("darwin", "win32"):
+    try:
+        matplotlib.use("TkAgg")
+    except Exception:
+        matplotlib.use("Agg")
+else:
+    # no display available (e.g. headless server via ssh): avoid an interactive
+    # backend, which would crash as soon as a figure is created
     matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # type: ignore
 from matplotlib.patches import Rectangle
@@ -131,7 +137,6 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
     contexts: List[Context] = []
     current_level: LevelIndex = 0
     current_position: Dict[LevelIndex, PositionIndex] = {0: 0}
-    plotting_axis = None  # type: ignore
     plotting_graph_buffer = None
     plotting_postions_buffer = None
 
@@ -147,10 +152,6 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
         self.pet = pet
         self.graph = nx.MultiDiGraph()
 
-        # define updating plot window
-        fig1 = plt.figure(1)
-        self.plotting_axis = fig1.add_subplot(1, 1, 1)
-        plt.ion()  # type: ignore[attr-defined]
         # start processing
         self.__assign_function_ids(pet)
         self.__construct_from_pet(pet)
@@ -158,9 +159,6 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
         self.__insert_data_dependencies_from_files(dynamic_dependency_file, static_dependency_file)
         self.__determine_loop_variables()
         self.__cleanup_loop_dependencies()
-        print("Waiting for user to close the Window...")
-        # plt.show(block=True)
-        plt.ioff()  # type: ignore[attr-defined]
 
     def __assign_function_ids(self, pet: PEGraphX) -> None:
         id = 0

--- a/explorer/discopop_explorer/discopop_explorer.py
+++ b/explorer/discopop_explorer/discopop_explorer.py
@@ -17,8 +17,10 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
-import tkinter as tk
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    import tkinter as tk
 
 import pstats2  # type: ignore
 from pluginbase import PluginBase  # type: ignore
@@ -50,8 +52,6 @@ from discopop_explorer.pattern_detection import PatternDetectorX
 
 from discopop_library.HostpotLoader.hostpot_loader import run as load_hotspots
 from discopop_library.tools.update_notifications.update_notifier import run as check_for_updates
-
-from discopop_gui.Visualizers.WithSidebar import WithSidebar as Visualizer
 
 
 @dataclass
@@ -87,7 +87,7 @@ class ExplorerArguments(GeneralArguments):
     enable_task_graph_plot: bool
     enable_context_graph_plot: bool
     enable_visualizer: bool
-    visualize_on: Optional[tk.Frame]
+    visualize_on: Optional["tk.Frame"]
 
     def __post_init__(self) -> None:
         self.__validate()
@@ -141,7 +141,7 @@ def __run(
     enable_task_graph_plot: bool = False,
     enable_context_graph_plot: bool = False,
     enable_visualizer: bool = False,
-    visualize_on: Optional[tk.Frame] = None,
+    visualize_on: Optional["tk.Frame"] = None,
 ) -> DetectionResult:
     # check for updates
     module_name = "discopop"
@@ -152,6 +152,10 @@ def __run(
     visualizer = None
 
     if enable_visualizer == True:
+        # imported lazily since it requires tkinter, which may be unavailable
+        # (e.g. on a headless server) when the GUI visualizer is not requested
+        from discopop_gui.Visualizers.WithSidebar import WithSidebar as Visualizer
+
         visualizer = Visualizer(visualize_on)
 
     pet = PEGraphX.from_parsed_input(*parse_inputs(cu_xml, dep_file, reduction_file, file_mapping), visualizer=visualizer)  # type: ignore

--- a/explorer/discopop_explorer/pattern_detection.py
+++ b/explorer/discopop_explorer/pattern_detection.py
@@ -40,7 +40,10 @@ from discopop_library.ParallelRegionMerger.inflated_parallel_region_pattern impo
 from discopop_explorer.pattern_detectors.new_task_detector import run_detection as detect_tasking
 from discopop_explorer.pattern_detectors.new_do_all_detector import run_detection as detect_do_all_and_reduction_new
 
-from discopop_gui.Visualizers.Base import Base as Visualizer
+try:
+    from discopop_gui.Visualizers.Base import Base as Visualizer
+except (ImportError, ModuleNotFoundError):
+    Visualizer = object  # type: ignore[assignment, misc]
 
 
 class PatternDetectorX(object):

--- a/explorer/discopop_explorer/pattern_detectors/new_do_all_detector.py
+++ b/explorer/discopop_explorer/pattern_detectors/new_do_all_detector.py
@@ -37,7 +37,6 @@ from discopop_explorer.pattern_detectors.task_parallelism.classes import (
     TPIType,
     TaskParallelismInfo,
 )
-from discopop_gui.Visualizers.WithSidebar import WithSidebar as VisualizerWithSideBar
 
 from discopop_explorer.utils import classify_loop_variables
 from discopop_explorer.functions.PEGraph.queries.edges import in_edges, out_edges

--- a/explorer/discopop_explorer/pattern_detectors/new_task_detector.py
+++ b/explorer/discopop_explorer/pattern_detectors/new_task_detector.py
@@ -34,7 +34,10 @@ from discopop_explorer.pattern_detectors.task_parallelism.classes import (
     TaskParallelismInfo,
 )
 
-from discopop_gui.Visualizers.Base import Base as Visualizer
+try:
+    from discopop_gui.Visualizers.Base import Base as Visualizer
+except (ImportError, ModuleNotFoundError):
+    Visualizer = object  # type: ignore[assignment, misc]
 
 logger = logging.getLogger("Explorer").getChild("Tasking")
 


### PR DESCRIPTION
TaskGraph unconditionally created a matplotlib figure with the TkAgg backend on every run, and several modules imported tkinter/discopop_gui at module level, both of which crash without a display (e.g. over SSH). Now the backend only goes interactive when DISPLAY is set, the eager figure creation is removed, and GUI imports are guarded/lazy so the explorer works without tkinter or a display unless visualization is explicitly requested.