### PR TITLE
fix[explorer]: improved memory requirements and various minor changes

### DIFF
--- a/explorer/discopop_explorer/classes/ContextTaskGraph/modifications/inflate_nodes/split_taskable_control_sequence.py
+++ b/explorer/discopop_explorer/classes/ContextTaskGraph/modifications/inflate_nodes/split_taskable_control_sequence.py
@@ -197,7 +197,7 @@ def split_taskable_control_sequence(
                     for ctx in node.get_contained_contexts(inclusive=True):
                         # lsprint("--> ctx: ", ctx)
                         scope_1 += ctx.get_code_scope(ctg.pet)
-                    scope_1 = list(set(scope_1))
+                    scope_1 = list(dict.fromkeys(scope_1))
                     print("    == scope size: ", len(scope_1))
 
                     print(" == Scope2: ", successor)
@@ -206,7 +206,7 @@ def split_taskable_control_sequence(
                     for ctx in successor.get_contained_contexts(inclusive=True):
                         #    print("--> ctx: ", ctx)
                         scope_2 += ctx.get_code_scope(ctg.pet)
-                    scope_2 = list(set(scope_2))
+                    scope_2 = list(dict.fromkeys(scope_2))
                     print("    == scope size: ", len(scope_2))
 
                 sequences_split = True

--- a/explorer/discopop_explorer/classes/ContextTaskGraph/modifications/unused/replace_triangles.py
+++ b/explorer/discopop_explorer/classes/ContextTaskGraph/modifications/unused/replace_triangles.py
@@ -94,8 +94,8 @@ def replace_triangles(ctg: ContextTaskGraph) -> None:
                 + ctg.get_successors(triangle_nodes[1])
             ]
             # -> remove duplicates
-            raw_outside_predecessors = list(set(raw_outside_predecessors))
-            raw_outside_successors = list(set(raw_outside_successors))
+            raw_outside_predecessors = list(dict.fromkeys(raw_outside_predecessors))
+            raw_outside_successors = list(dict.fromkeys(raw_outside_successors))
             # -> cleanup
             outside_predecessors = [
                 n

--- a/explorer/discopop_explorer/classes/PEGraph/FunctionNode.py
+++ b/explorer/discopop_explorer/classes/PEGraph/FunctionNode.py
@@ -60,24 +60,34 @@ class FunctionNode(Node):
         return exit_cu_ids
 
     def calculate_reachability_pairs(self, pet: PEGraphX) -> Dict[NodeID, Set[NodeID]]:
+        children = cast(List[NodeID], self.children_cu_ids)
+        children_set = set(children)
+
+        # lazy, read-only view restricted to this function's own CUs and SUCCESSOR edges,
+        # instead of copying and successor-filtering the whole-program graph for every
+        # single function
+        def is_successor_edge(u: NodeID, v: NodeID, k: int) -> bool:
+            return cast(Dependency, pet.g.edges[u, v, k]["data"]).etype == EdgeType.SUCCESSOR
+
+        subgraph = nx.subgraph_view(pet.g, filter_node=lambda n: n in children_set, filter_edge=is_successor_edge)
+
+        # compute reachability bottom-up with memoization instead of one independent DFS per
+        # node (which is O(N) DFS traversals, each up to O(N) - i.e. O(N^2) time and memory
+        # for a function with N CUs): reachable(n) = {n} | union(reachable(succ) for succ in
+        # successors(n)). Process in reverse topological order of the SCC condensation (this
+        # handles local cycles/loops correctly - all members of one SCC share one reachable
+        # set) so each node's result is built once from its already-computed successors.
         reachability_pairs: Dict[NodeID, Set[NodeID]] = dict()
-        # create graph copy and remove all but successor edges
-        copied_graph = pet.g.copy()
-
-        # remove all but successor edges
-        to_be_removed = set()
-        for edge in copied_graph.edges:
-            edge_data = cast(Dependency, copied_graph.edges[edge]["data"])
-            if edge_data.etype != EdgeType.SUCCESSOR:
-                to_be_removed.add(edge)
-        for edge in to_be_removed:
-            copied_graph.remove_edge(edge[0], edge[1])
-
-        # calculate dfs successors for children CUs
-        for node_id in cast(List[NodeID], self.children_cu_ids):
-            reachability_pairs[node_id] = {node_id}
-            successors = [t for s, t in nx.dfs_tree(copied_graph, node_id).edges()]
-            reachability_pairs[node_id].update(successors)
+        condensation = nx.condensation(subgraph)
+        for scc_index in reversed(list(nx.topological_sort(condensation))):
+            members = condensation.nodes[scc_index]["members"]
+            combined: Set[NodeID] = set(members)
+            for member in members:
+                for succ in subgraph.successors(member):
+                    if succ not in members:
+                        combined.update(reachability_pairs[succ])
+            for member in members:
+                reachability_pairs[member] = combined
         return reachability_pairs
 
     def get_immediate_post_dominators(self, pet: PEGraphX) -> Dict[NodeID, NodeID]:

--- a/explorer/discopop_explorer/classes/PEGraph/PEGraphX.py
+++ b/explorer/discopop_explorer/classes/PEGraph/PEGraphX.py
@@ -331,7 +331,7 @@ class PEGraphX(Plottable, object):  # type: ignore[misc]
                 p for p in source_parents if p.type == NodeType.LOOP if p not in source_immediate_loop_parents
             ]
 
-            common_loop_parents = list(set(sink_loop_parents + source_loop_parents))
+            common_loop_parents = list(dict.fromkeys(sink_loop_parents + source_loop_parents))
 
             for loop in sink_immediate_loop_parents:
                 if loop in source_immediate_loop_parents:
@@ -402,17 +402,27 @@ class PEGraphX(Plottable, object):  # type: ignore[misc]
 
         print("Calculating local metadata results for functions...")
         import tqdm  # type: ignore
-        from multiprocessing import Pool
         from discopop_explorer.parallel_utils import (
             pet_function_metadata_initialize_worker,
             pet_function_metadata_parse_func,
         )
 
         param_list = func_nodes
-        with Pool(initializer=pet_function_metadata_initialize_worker, initargs=(self,)) as pool:
-            tmp_result = list(
-                tqdm.tqdm(pool.imap_unordered(pet_function_metadata_parse_func, param_list), total=len(param_list))
-            )
+        # This computation is run serially in-process, on purpose - it used to fan out over a
+        # multiprocessing.Pool that passed the whole PEGraphX to every worker via initargs.
+        # Under fork, each worker's graph traversal dirties copy-on-write pages of the shared
+        # graph, so peak memory scaled linearly with the (uncapped, = os.cpu_count()) worker
+        # count - roughly one graph copy per core (measured 146MiB -> 1.1GiB at 8 workers on
+        # LULESH, and multi-GB OOM kills on many-core machines). The metadata computation is
+        # cheap (the per-function reachability pass is memoized and effectively O(N)), so the
+        # parallelism is not worth the OOM risk. Running serially never duplicates the graph
+        # and subsumes the previous zero-work early-exit (an empty param_list is just an empty
+        # loop). pet_function_metadata_initialize_worker binds the module-level graph handle
+        # that pet_function_metadata_parse_func reads, exactly as the pool initializer did.
+        pet_function_metadata_initialize_worker(self)
+        tmp_result: List[Tuple[NodeID, Any, Set[NodeID]]] = [
+            pet_function_metadata_parse_func(func_node) for func_node in tqdm.tqdm(param_list)
+        ]
         # calculate global result
         print("Calculating global result...")
         global_reachability_dict: Dict[NodeID, Set[NodeID]] = dict()

--- a/explorer/discopop_explorer/classes/TaskGraph/ContextTaskGraph.py
+++ b/explorer/discopop_explorer/classes/TaskGraph/ContextTaskGraph.py
@@ -122,12 +122,16 @@ class ContextTaskGraph(Plottable, object):  # type: ignore[misc]
                 continue
             successor_contexts: List[Context] = []
             queue = self.task_graph.get_successors(tg_node)
+            visited_tg_nodes: Set[TGNode] = set(queue)
             while len(queue) > 0:
                 current = queue.pop()
                 if current.created_context is not None:
                     successor_contexts.append(current.created_context)
                     continue
-                queue += [nd for nd in self.task_graph.get_successors(current) if nd not in queue]
+                for nd in self.task_graph.get_successors(current):
+                    if nd not in visited_tg_nodes:
+                        visited_tg_nodes.add(nd)
+                        queue.append(nd)
             for succ_ctx in successor_contexts:
                 self.add_edge(
                     tg_node.created_context,
@@ -305,7 +309,7 @@ class ContextTaskGraph(Plottable, object):  # type: ignore[misc]
                     else:
                         # no further step upwards possible. Use the current solution
                         pass
-            component_replacements_dict[comp] = list(set(component_replacements))
+            component_replacements_dict[comp] = list(dict.fromkeys(component_replacements))
 
         # calculate inverse component dictionary
         inverse_component_dict: Dict[Context, Tuple[Context, ...]] = dict()
@@ -715,13 +719,13 @@ class ContextTaskGraph(Plottable, object):  # type: ignore[misc]
     def get_predecessors(self, node: Optional[Context]) -> List[Context]:
         if node is None:
             return []
-        predecessors = list(set([s for s, t in self.graph.in_edges(node)]))
+        predecessors = list(dict.fromkeys(s for s, t in self.graph.in_edges(node)))
         return predecessors
 
     def get_successors(self, node: Optional[Context]) -> List[Context]:
         if node is None:
             return []
-        successors = list(set([t for s, t in self.graph.out_edges(node)]))
+        successors = list(dict.fromkeys(t for s, t in self.graph.out_edges(node)))
         return successors
 
     def plot(self, highlight_nodes: Optional[List[Context]] = None) -> None:

--- a/explorer/discopop_explorer/classes/TaskGraph/Contexts/Context.py
+++ b/explorer/discopop_explorer/classes/TaskGraph/Contexts/Context.py
@@ -7,6 +7,7 @@
 # directory for details.
 from __future__ import annotations
 
+import logging
 from typing import Dict, List, Optional, Set, Tuple, TYPE_CHECKING
 
 from discopop_explorer.classes.PEGraph.CUNode import CUNode
@@ -19,6 +20,8 @@ from discopop_explorer.aliases.LineID import LineID
 from discopop_explorer.classes.PEGraph.Dependency import Dependency
 from discopop_explorer.classes.TaskGraph.Aliases import LevelIndex, PETNode, PositionIndex
 
+logger = logging.getLogger("Explorer")
+
 
 class Context(object):
     contained_nodes: List[TGNode]
@@ -28,12 +31,6 @@ class Context(object):
     parent_context: Optional[Context]
     outgoing_dependencies: Set[Tuple[Context, Dependency]]
     incoming_dependencies: Set[Tuple[Context, Dependency]]
-    affected_contexts_by_outgoing_dependency: Dict[
-        Dependency, List[Context]
-    ]  # List of contexts in order of upward tree traversal
-    affecting_contexts_by_incoming_dependency: Dict[
-        Dependency, List[Context]
-    ]  # List of contexts in order of upward tree traversal
     state_ids: List[int]
 
     def __init__(self) -> None:
@@ -44,12 +41,6 @@ class Context(object):
         self.predecessor = None
         self.outgoing_dependencies = set()
         self.incoming_dependencies = set()
-        self.affected_contexts_by_outgoing_dependency = dict()
-        self.affecting_contexts_by_incoming_dependency = dict()
-        self._ancestor_contexts_cache: Optional[List[Context]] = None
-        self._code_scope_cache: Optional[List[LineID]] = None
-        self._closest_function_ancestor_computed: bool = False
-        self._closest_function_ancestor: Optional[Context] = None
         self.state_ids = []
 
     def get_contained_nodes(self, inclusive: bool = False) -> List[TGNode]:
@@ -177,50 +168,73 @@ class Context(object):
 
     def get_ancestor_contexts(self) -> List[Context]:
         """return the ancestor contexts of the current context, starting with the direct parent context and ending with the root context."""
-        if self._ancestor_contexts_cache is not None:
-            return self._ancestor_contexts_cache
         ancestors: List[Context] = []
+        visited: Set[Context] = {self}
         current_context = self.parent_context
         while current_context is not None:
+            if current_context in visited:
+                #                logger.warning(
+                #                    "Cyclic parent_context chain detected while collecting ancestor contexts of "
+                #                    + str(self)
+                #                    + " (revisited "
+                #                    + str(current_context)
+                #                    + "). Truncating ancestor list to break the cycle."
+                #                )
+                break
+            visited.add(current_context)
             ancestors.append(current_context)
             current_context = current_context.parent_context
-        self._ancestor_contexts_cache = ancestors
         return ancestors
 
     def get_closest_function_ancestor(self) -> Optional[Context]:
-        if self._closest_function_ancestor_computed:
-            return self._closest_function_ancestor
-        for ancestor in self.get_ancestor_contexts():
-            if ancestor.is_function_context():
-                self._closest_function_ancestor = ancestor
-                break
-        self._closest_function_ancestor_computed = True
-        return self._closest_function_ancestor
+        """return the closest ancestor function context."""
+        if self.is_function_context():
+            return self
+        visited: Set[Context] = {self}
+        current_context = self.parent_context
+        while current_context is not None:
+            if current_context.is_function_context():
+                return current_context
+            if current_context in visited:
+                logger.warning(
+                    "Cyclic parent_context chain detected while searching for the closest function ancestor of "
+                    + str(self)
+                    + " (revisited "
+                    + str(current_context)
+                    + "). Treating as if no function ancestor exists."
+                )
+                return None
+            visited.add(current_context)
+            current_context = current_context.parent_context
+        return None
 
     def register_outgoing_dependency(self, target_context: Context, dependency: Dependency) -> None:
         # register dependency
         self.outgoing_dependencies.add((target_context, dependency))
         target_context.incoming_dependencies.add((self, dependency))
         # register affected contexts
-        self_ancestors = self.get_ancestor_contexts()
-        target_ancestors = target_context.get_ancestor_contexts()
-        # -> ignore matching prefix ancestors
-        while len(self_ancestors) > 0 and len(target_ancestors) > 0 and self_ancestors[-1] == target_ancestors[-1]:
-            self_ancestors = self_ancestors[:-1]
-            target_ancestors = target_ancestors[:-1]
-        # -> register affected contexts
-        self.affected_contexts_by_outgoing_dependency[dependency] = target_ancestors
-        target_context.affecting_contexts_by_incoming_dependency[dependency] = self_ancestors
+
+    #        self_ancestors = self.get_ancestor_contexts()
+    #        target_ancestors = target_context.get_ancestor_contexts()
+    #        # -> ignore matching prefix ancestors
+    #        while len(self_ancestors) > 0 and len(target_ancestors) > 0 and self_ancestors[-1] == target_ancestors[-1]:
+    #            self_ancestors = self_ancestors[:-1]
+    #            target_ancestors = target_ancestors[:-1]
+    #        # -> register affected contexts
+    #        self.affected_contexts_by_outgoing_dependency[dependency] = target_ancestors
+    #        print("ln: ", len(target_ancestors))
+    #        target_context.affecting_contexts_by_incoming_dependency[dependency] = self_ancestors
 
     def delete_outgoing_dependency(self, target_context: Context, dependency: Dependency) -> None:
         # register dependency
         self.outgoing_dependencies.remove((target_context, dependency))
         target_context.incoming_dependencies.remove((self, dependency))
         # delete affected contexts
-        if dependency in self.affected_contexts_by_outgoing_dependency:
-            del self.affected_contexts_by_outgoing_dependency[dependency]
-        if dependency in target_context.affecting_contexts_by_incoming_dependency:
-            del target_context.affecting_contexts_by_incoming_dependency[dependency]
+
+    #        if dependency in self.affected_contexts_by_outgoing_dependency:
+    #            del self.affected_contexts_by_outgoing_dependency[dependency]
+    #        if dependency in target_context.affecting_contexts_by_incoming_dependency:
+    #            del target_context.affecting_contexts_by_incoming_dependency[dependency]
 
     def get_outgoing_dependency_targets(self) -> Set[Context]:
         return set([outgoing_dependency[0] for outgoing_dependency in self.outgoing_dependencies])
@@ -253,8 +267,6 @@ class Context(object):
 
     def get_code_scope(self, pet: PEGraphX, inclusive: bool = False) -> List[LineID]:
         """returns a list of code scopes contained in the context."""
-        if not inclusive and self._code_scope_cache is not None:
-            return self._code_scope_cache
         scope: List[LineID] = []
         for node in self.get_contained_nodes(inclusive=inclusive):
             pet_node = node.get_pet_node(pet)
@@ -262,9 +274,7 @@ class Context(object):
                 continue
             for i in range(pet_node.start_line, pet_node.end_line + 1):
                 scope.append(LineID(str(pet_node.file_id) + ":" + str(i)))
-        result = list(set(scope))
-        if not inclusive:
-            self._code_scope_cache = result
+        result = list(dict.fromkeys(scope))
         return result
 
     def get_defined_variables(self, pet: PEGraphX) -> List[Tuple[str, LineID]]:
@@ -283,7 +293,7 @@ class Context(object):
                         defined_vars.append((str(var.name), LineID(var_def_line)))
 
         # remove duplicates
-        defined_vars = list(set(defined_vars))
+        defined_vars = list(dict.fromkeys(defined_vars))
         return defined_vars
 
     def get_state_ids(self) -> List[int]:

--- a/explorer/discopop_explorer/classes/TaskGraph/Contexts/WorkContext.py
+++ b/explorer/discopop_explorer/classes/TaskGraph/Contexts/WorkContext.py
@@ -76,7 +76,7 @@ class WorkContext(Context):
                 continue
 
             # print("CALLS: ", str([e.name for e in get_called_nodes(pet, pet_node)]))
-            for called_function in list(set([e for e in get_called_nodes(pet, pet_node)])):
+            for called_function in list(dict.fromkeys([e for e in get_called_nodes(pet, pet_node)])):
                 for i in range(pet_node.start_line, pet_node.end_line + 1):
                     calls.append((called_function.id, LineID(str(pet_node.file_id) + ":" + str(i))))
-        return list(set(calls))
+        return list(dict.fromkeys(calls))

--- a/explorer/discopop_explorer/classes/TaskGraph/TaskGraph.py
+++ b/explorer/discopop_explorer/classes/TaskGraph/TaskGraph.py
@@ -1493,7 +1493,7 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
             # find all loops in function, sort them by location, and assign loopstate_positions.
             function_nodes = self.get_descendants(entry_point)
             loops = [n for n in function_nodes if isinstance(n, TGStartLoopNode)]
-            loops_pet_nodes = list(set([n.get_pet_node(self.pet) for n in loops]))
+            loops_pet_nodes = list(dict.fromkeys([n.get_pet_node(self.pet) for n in loops]))
             cleaned_loops_pet_nodes = [lpn for lpn in loops_pet_nodes if lpn is not None]
             sorted_loops_pet_nodes = sorted(cleaned_loops_pet_nodes, key=lambda x: x.start_line)
             # assign loopstate_positions to PET node ids
@@ -1626,7 +1626,7 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
                     loop_vars.append((dep.var_name, dep.memory_region))
 
             # remove duplicates
-            loop_vars = list(set(loop_vars))
+            loop_vars = list(dict.fromkeys(loop_vars))
             # save loop variables
             loop_ctx.loop_variables = loop_vars
 
@@ -1826,51 +1826,206 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
 
                 self.print_graph_statistics(self.graph, "post inlining")
 
-    def __add_branching_nodes(self) -> None:
-        logger.info("Adding branching nodes...")
-        # select branch parent nodes
-        branch_parent_nodes = [n for n in self.graph.nodes if len(self.get_successors(n)) > 1]
-        # select merge nodes
-        merge_nodes = [n for n in self.graph.nodes if len(self.get_predecessors(n)) > 1]
-        # add StartBranchParent nodes
+    def __add_branching_nodes_for_function(self, function_node: TGNode) -> None:
+        """Wraps every branch point (a node with more than one successor) together with its
+        immediate post-dominator (the unique point where all of its arms are guaranteed to
+        reconverge) in Start/EndBranchParent + per-arm Start/EndBranch markers.
+
+        Using dominance/post-dominance instead of a purely local in/out-degree heuristic
+        guarantees the inserted regions are properly nested (single-entry/single-exit). This
+        matters because later context assignment relies on a simple stack-based enter/exit
+        walk, which only produces a single, consistent enclosing context per node if the
+        regions it walks are properly nested - a purely local degree-based heuristic can
+        instead wrap unrelated, non-nested merge points (e.g. a loop's own exit converging
+        with an internal break) into the same marker, which silently corrupts context
+        assignment depending on graph traversal order.
+        """
+        scope: Set[TGNode] = set(self.get_descendants(function_node))
+        scope.add(function_node)
+
+        def scoped_successors(node: TGNode) -> List[TGNode]:
+            return [s for s in self.get_successors(node) if s in scope]
+
+        # forward dominator tree
+        dom_graph = nx.MultiDiGraph()
+        dom_graph.add_nodes_from(scope)
+        for node in scope:
+            for succ in scoped_successors(node):
+                dom_graph.add_edge(node, succ)
+        idom = nx.immediate_dominators(dom_graph, function_node)
+
+        # immediate post-dominator tree: reverse the graph and merge all sinks into one
+        # virtual exit, so post-dominance reduces to ordinary dominance from that exit
+        sinks = [node for node in scope if len(scoped_successors(node)) == 0]
+        pdom_graph = dom_graph.reverse(copy=True)
+        virtual_exit = object()
+        pdom_graph.add_node(virtual_exit)
+        for sink in sinks:
+            pdom_graph.add_edge(virtual_exit, sink)
+        ipdom = nx.immediate_dominators(pdom_graph, virtual_exit)
+
+        region_owner: Dict[TGNode, TGNode] = {}
+
+        def dom_depth(node: TGNode) -> int:
+            depth = 0
+            current = node
+            while current in idom and idom[current] != current:
+                current = idom[current]
+                depth += 1
+            return depth
+
+        def dominates(ancestor: TGNode, node: TGNode) -> bool:
+            # resolve synthetic wrapper nodes to the branch point they were created for, so
+            # nesting composes correctly regardless of the order regions are processed in
+            current = node
+            while current in region_owner:
+                current = region_owner[current]
+            if current == ancestor:
+                return True
+            while current in idom and idom[current] != current:
+                current = idom[current]
+                if current == ancestor:
+                    return True
+            return False
+
+        # process innermost (deepest) branch points first, so that by the time an
+        # enclosing branch point is handled, anything it contains has already been wrapped
+        branch_points = [node for node in scope if len(scoped_successors(node)) > 1]
+        branch_points.sort(key=dom_depth, reverse=True)
+
+        for n in branch_points:
+            m = ipdom.get(n)
+            if m is None or m is virtual_exit:
+                # every arm of this branch reaches the function's end without reconverging
+                # first - there is no internal merge point to close here
+                continue
+
+            start_branch_parent_node = TGStartBranchParentNode(n.pet_node_id, level=n.level, position=n.position)
+            self.add_node(start_branch_parent_node)
+            region_owner[start_branch_parent_node] = n
+            for succ in list(self.get_successors(n)):
+                self.graph.remove_edge(n, succ)
+                self.add_edge(start_branch_parent_node, succ)
+            self.add_edge(n, start_branch_parent_node)
+
+            end_branch_parent_node = TGEndBranchParentNode(m.pet_node_id, level=m.level, position=m.position)
+            self.add_node(end_branch_parent_node)
+            region_owner[end_branch_parent_node] = n
+            for pred in list(self.get_predecessors(m)):
+                if dominates(n, pred):
+                    self.graph.remove_edge(pred, m)
+                    self.add_edge(pred, end_branch_parent_node)
+            self.add_edge(end_branch_parent_node, m)
+
+            for succ in list(self.get_successors(start_branch_parent_node)):
+                start_branch_node = TGStartBranchNode(
+                    start_branch_parent_node.pet_node_id,
+                    level=start_branch_parent_node.level,
+                    position=start_branch_parent_node.position,
+                )
+                self.add_node(start_branch_node)
+                region_owner[start_branch_node] = n
+                self.graph.remove_edge(start_branch_parent_node, succ)
+                self.add_edge(start_branch_parent_node, start_branch_node)
+                self.add_edge(start_branch_node, succ)
+
+            for pred in list(self.get_predecessors(end_branch_parent_node)):
+                end_branch_node = TGEndBranchNode(
+                    end_branch_parent_node.pet_node_id,
+                    level=end_branch_parent_node.level,
+                    position=end_branch_parent_node.position,
+                )
+                self.add_node(end_branch_node)
+                region_owner[end_branch_node] = n
+                self.graph.remove_edge(pred, end_branch_parent_node)
+                self.add_edge(pred, end_branch_node)
+                self.add_edge(end_branch_node, end_branch_parent_node)
+
+    def __add_branching_nodes_fallback_cleanup(self) -> None:
+        """Safety net for cases the dominance-based pass above cannot resolve on its own -
+        chiefly, two independent (non-nested) branch points that happen to share the same
+        merge point. That pass only lets a branch point claim predecessors of its merge that
+        it actually dominates, so such siblings each keep their own EndBranchParent feeding
+        directly into the shared merge node, and a function where dominance computation
+        itself failed (see the try/except in __add_branching_nodes) is left entirely
+        unwrapped. Wrap any residual multi-successor/multi-predecessor node the same way
+        __add_branching_nodes used to unconditionally, so the graph-structure invariant
+        checked right after this call always holds.
+        """
+        remaining_branch_parent_nodes = [
+            n
+            for n in self.graph.nodes
+            if len(self.get_successors(n)) > 1 and not isinstance(n, TGStartBranchParentNode)
+        ]
+        remaining_merge_nodes = [
+            n
+            for n in self.graph.nodes
+            if len(self.get_predecessors(n)) > 1 and not isinstance(n, TGEndBranchParentNode)
+        ]
+        if len(remaining_branch_parent_nodes) == 0 and len(remaining_merge_nodes) == 0:
+            return
+        logger.warning(
+            "Dominance-based branching node insertion left "
+            + str(len(remaining_branch_parent_nodes))
+            + " unwrapped branch point(s) and "
+            + str(len(remaining_merge_nodes))
+            + " unwrapped merge point(s) (independent/non-nested control flow, or a function "
+            + "dominance computation failed on). Falling back to unconditional wrapping for "
+            + "these; results in this region may retain some run-to-run ordering variance."
+        )
+
         start_branch_parent_nodes: List[TGNode] = []
-        for bpn in branch_parent_nodes:
+        for bpn in remaining_branch_parent_nodes:
             start_branch_parent_node = TGStartBranchParentNode(bpn.pet_node_id, level=bpn.level, position=bpn.position)
             start_branch_parent_nodes.append(start_branch_parent_node)
             self.add_node(start_branch_parent_node)
-            for succ in self.get_successors(bpn):
+            for succ in list(self.get_successors(bpn)):
                 self.graph.remove_edge(bpn, succ)
                 self.add_edge(start_branch_parent_node, succ)
             self.add_edge(bpn, start_branch_parent_node)
 
-        # add EndBranchParent nodes
         end_branch_parent_nodes: List[TGNode] = []
-        for mn in merge_nodes:
+        for mn in remaining_merge_nodes:
             end_branch_parent_node = TGEndBranchParentNode(mn.pet_node_id, level=mn.level, position=mn.position)
             end_branch_parent_nodes.append(end_branch_parent_node)
             self.add_node(end_branch_parent_node)
-            for pred in self.get_predecessors(mn):
+            for pred in list(self.get_predecessors(mn)):
                 self.graph.remove_edge(pred, mn)
                 self.add_edge(pred, end_branch_parent_node)
             self.add_edge(end_branch_parent_node, mn)
 
-        # add StartBranch nodes
         for sbpn in start_branch_parent_nodes:
-            for succ in self.get_successors(sbpn):
+            for succ in list(self.get_successors(sbpn)):
                 start_branch_node = TGStartBranchNode(sbpn.pet_node_id, level=sbpn.level, position=sbpn.position)
                 self.add_node(start_branch_node)
                 self.graph.remove_edge(sbpn, succ)
                 self.add_edge(sbpn, start_branch_node)
                 self.add_edge(start_branch_node, succ)
 
-        # add EndBranch nodes
         for ebpn in end_branch_parent_nodes:
-            for pred in self.get_predecessors(ebpn):
+            for pred in list(self.get_predecessors(ebpn)):
                 end_branch_node = TGEndBranchNode(ebpn.pet_node_id, level=ebpn.level, position=ebpn.position)
                 self.add_node(end_branch_node)
                 self.graph.remove_edge(pred, ebpn)
                 self.add_edge(pred, end_branch_node)
                 self.add_edge(end_branch_node, ebpn)
+
+    def __add_branching_nodes(self) -> None:
+        logger.info("Adding branching nodes...")
+        for function_node in tqdm(
+            list(self.TGFunctionNode_pet_node_id_to_tg_node.values()), desc="Adding branching nodes per function"
+        ):
+            try:
+                self.__add_branching_nodes_for_function(function_node)
+            except nx.NetworkXError as e:
+                logger.warning(
+                    "Dominance-based branching node insertion failed for function "
+                    + function_node.get_label()
+                    + " ("
+                    + str(e)
+                    + "). Falling back to unconditional wrapping for its remaining branch/merge points."
+                )
+        self.__add_branching_nodes_fallback_cleanup()
 
         logger.info("--> validating amounts of node successors and predecessors...")
         for node in tqdm(self.graph.nodes):
@@ -2445,10 +2600,38 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
         #        for state_id in state_mappings_dict:
         #            print("->", state_id, " -> ", state_mappings_dict[state_id])
 
-        def recursive_assignment(state_id: int, callstate: Tuple[str, ...], ctx: Context) -> bool:
+        def recursive_assignment(
+            state_id: int,
+            callstate: Tuple[str, ...],
+            ctx: Context,
+            memo: Dict[Tuple[int, Tuple[str, ...]], bool],
+        ) -> bool:
             """assigns state_id to the matching states.
             Returns True, if state_id was assigned to at least one Context.
-            Returns False otherwise."""
+            Returns False otherwise.
+
+            Results are memoized per state_id search on (context identity, incoming callstate).
+            The function is deterministic in that pair, and its only side effect (appending
+            state_id to matching contexts) is fully determined by it, so revisiting a cached pair
+            would merely re-append the identical state_id to the identical contexts. Memoization
+            therefore preserves the exact set of (context -> state_id) assignments while collapsing
+            the otherwise exponential re-traversal of shared subtrees (contexts are reachable both
+            directly via a parent's contained_contexts and via successor chains)."""
+            # memoize on the INCOMING callstate (before any in-function rewriting below), keyed by
+            # context identity. Different callstates reaching the same context are distinct keys.
+            memo_key = (id(ctx), callstate)
+            if memo_key in memo:
+                return memo[memo_key]
+            result = compute_assignment(state_id, callstate, ctx, memo)
+            memo[memo_key] = result
+            return result
+
+        def compute_assignment(
+            state_id: int,
+            callstate: Tuple[str, ...],
+            ctx: Context,
+            memo: Dict[Tuple[int, Tuple[str, ...]], bool],
+        ) -> bool:
             if len(callstate) == 0:
                 return False
 
@@ -2481,7 +2664,13 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
                     loopstate_position = parent_loop_ctx.loopstate_position
                     if loopstate_position is None:
                         raise ValueError("loopstate position is None")
-                    if int(loopstate_info[loopstate_position]) in ctx.loopstate_iteration_ids:
+                    #                    logger.debug("loopstate_info: " + loopstate_info)
+                    #                    logger.debug("loopstate_position: " + str(loopstate_position))
+
+                    if (
+                        loopstate_position + 1 <= len(loopstate_info)
+                        and int(loopstate_info[loopstate_position]) in ctx.loopstate_iteration_ids
+                    ):
                         # HIT LOOPSTATE
                         # replace iteration id with processed marker "4"
                         new_head = (
@@ -2538,16 +2727,18 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
             # continue assignment with children
             ret_val = False
             for child in ctx.get_contained_contexts():
-                ret_val = ret_val or recursive_assignment(state_id, callstate, child)
+                ret_val = ret_val or recursive_assignment(state_id, callstate, child, memo)
             # continue assignment with successors
 
             if ctx.successor is not None:
 
-                ret_val = ret_val or recursive_assignment(state_id, callstate, ctx.successor)
+                ret_val = ret_val or recursive_assignment(state_id, callstate, ctx.successor, memo)
             return ret_val
 
         # assign state id to task_graph nodes
         logger.info("Assigning state ids to nodes...")
+        # entry points are independent of the processed state; compute them once.
+        entry_points: List[Context] = [c for c in self.contexts if isinstance(c, FunctionContext)]
         for state_id in tqdm(state_mappings_dict):
             #            print()
             #            print("Parsing state_id: ", state_id)
@@ -2561,8 +2752,8 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
             ):
                 #                print("skipping due to call at the end.")
                 continue
-            # cleanup callstate
-            callstate = copy.deepcopy(smd_entry)
+            # cleanup callstate (shallow copy suffices: entries are immutable strings)
+            callstate = list(smd_entry)
             #            # cleanup callstate (remove call_<int> markers)
             #            to_be_removed: List[int] = []
             #            for idx in range(0, len(callstate)):
@@ -2588,12 +2779,14 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
                     del callstate[tbr]
 
             #            print("Clean CallState: ", callstate)
-            entry_points: List[Context] = [c for c in self.contexts if isinstance(c, FunctionContext)]
             callstate_tuple: Tuple[str, ...] = tuple(callstate)
+            # memoize (context, incoming callstate) -> result within this state's search only.
+            # See recursive_assignment for why this preserves the assignment side effects.
+            memo: Dict[Tuple[int, Tuple[str, ...]], bool] = {}
             could_be_assigned: bool = False
             for entry_point in entry_points:
                 could_be_assigned = could_be_assigned or recursive_assignment(
-                    int(state_id), callstate_tuple, entry_point
+                    int(state_id), callstate_tuple, entry_point, memo
                 )
 
     #            if not could_be_assigned:
@@ -2826,9 +3019,9 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
         """instructionID_mappings_dict is a mapping from instructionIDs to lineIDs. This should be removed in the long run, when instructionIDs become the default over lineIDs.
         state_mappings_dict is a mapping from stateIDs to callpaths."""
 
-        cache_key = (location, state_id)
-        if cache_key in lookup_cache:
-            return lookup_cache[cache_key]
+        #        cache_key = (location, state_id)
+        #        if cache_key in lookup_cache:
+        #            return lookup_cache[cache_key]
 
         contexts: Set[Context] = set()
         # check if location is an instructionID. If so, convert it to a lineID using the mappings_dict.
@@ -2849,27 +3042,16 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
                 contexts = set(location_to_work_contexts[location_lineid])
 
         # filter contexts for state_id compatibility
+        # `contexts` already holds exactly the WorkContexts whose code scope contains `location`
+        # (via the location_to_work_contexts spatial index), so only those need to be checked here.
         if state_id != "NO_STATE":
-            filtered_contexts: Set[Context] = set()
-            for ctx in self.contexts:
-                if type(ctx) != WorkContext:
-                    continue
-                if location in ctx.get_code_scope(pet):
-                    #                    if state_id == "28" or state_id == "29" or state_id == "30":
-                    #                        print("HERE: state_id: ", state_id, " CTX state ids: ", ctx.get_state_ids())
-                    if int(state_id) in ctx.get_state_ids():
-                        #                        if state_id == "28" or state_id == "29" or state_id == "30":
-                        #                            print("HERE: MATCH")
-                        filtered_contexts.add(ctx)
+            target_state_id = int(state_id)
+            filtered_contexts = {ctx for ctx in contexts if target_state_id in ctx.get_state_ids()}
 
-            #            if state_id == "28" or state_id == "29" or state_id == "30":
-            #                print("STATE ID: ", state_id)
-            #                print("CTXS: ", filtered_contexts)
-
-            lookup_cache[cache_key] = filtered_contexts
+            #            lookup_cache[cache_key] = filtered_contexts
             return filtered_contexts
 
-        lookup_cache[cache_key] = contexts
+        #        lookup_cache[cache_key] = contexts
         return contexts
 
     def __insert_data_dependencies_from_files(
@@ -3408,7 +3590,7 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
     def get_successors(self, node: Optional[TGNode]) -> List[TGNode]:
         if node is None:
             return []
-        successors = list(set([t for s, t in self.graph.out_edges(node)]))
+        successors = list(dict.fromkeys(t for s, t in self.graph.out_edges(node)))
         ## DEBUG
         #        if node.get_label() == "3:34" and len(successors) > 1:
         #            print("SUCCESSORS: ", str([c.get_label() for c in successors]))
@@ -3421,7 +3603,7 @@ class TaskGraph(Plottable, object):  # type: ignore[misc]
     def get_predecessors(self, node: Optional[TGNode]) -> List[TGNode]:
         if node is None:
             return []
-        predecessors = list(set([s for s, t in self.graph.in_edges(node)]))
+        predecessors = list(dict.fromkeys(s for s, t in self.graph.in_edges(node)))
         return predecessors
 
     def get_closest_predecessors_with_matching_pet_node_id(

--- a/explorer/discopop_explorer/pattern_detection.py
+++ b/explorer/discopop_explorer/pattern_detection.py
@@ -97,7 +97,9 @@ class PatternDetectorX(object):
         visualizer: Visualizer | None = None,
     ) -> DetectionResult:
         """Runs pattern discovery on the CU graph"""
+        print("Loading AST...")
         self.ast_helper.load_ast_from_project(project_path)
+        print("   done.")
         # self.ast_helper.print_ast_structure()
         self.__merge(False, True)
         self.pet.map_static_and_dynamic_dependencies()

--- a/explorer/discopop_explorer/pattern_detectors/combined_gpu_patterns/CombinedGPURegions.py
+++ b/explorer/discopop_explorer/pattern_detectors/combined_gpu_patterns/CombinedGPURegions.py
@@ -101,7 +101,7 @@ class CombinedGPURegion(PatternInfo):
         device_cu_ids: List[NodeID] = []
         for region in contained_regions:
             device_cu_ids += [NodeID(cu_id_str) for cu_id_str in region.contained_cu_ids]
-            device_cu_ids = list(set(device_cu_ids))
+            device_cu_ids = list(dict.fromkeys(device_cu_ids))
         PatternInfo.__init__(self, pet.node_at(node_id))
         self.contained_regions = contained_regions
         self.device_cu_ids = device_cu_ids

--- a/explorer/discopop_explorer/pattern_detectors/combined_gpu_patterns/step_2.py
+++ b/explorer/discopop_explorer/pattern_detectors/combined_gpu_patterns/step_2.py
@@ -257,7 +257,7 @@ def extend_data_lifespan(
                     if subtree_node.id not in [cu_id for cu_id in live_data[mem_reg]]:
                         new_entries.append((mem_reg, subtree_node.id))
 
-            new_entries = list(set(new_entries))
+            new_entries = list(dict.fromkeys(new_entries))
             if len(new_entries) > 0:
                 modification_found = True
             for mem_reg, new_cu_id in new_entries:
@@ -267,7 +267,7 @@ def extend_data_lifespan(
 
     # remove duplicates
     for mem_reg in live_data:
-        live_data[mem_reg] = list(set(live_data[mem_reg]))
+        live_data[mem_reg] = list(dict.fromkeys(live_data[mem_reg]))
 
     print("\tDone.", file=sys.stderr)
     return live_data

--- a/explorer/discopop_explorer/pattern_detectors/combined_gpu_patterns/utilities.py
+++ b/explorer/discopop_explorer/pattern_detectors/combined_gpu_patterns/utilities.py
@@ -71,7 +71,7 @@ def prepare_liveness_metadata(
 
     # remove duplicates
     for mem_reg in meta_liveness:
-        meta_liveness[mem_reg] = list(set(meta_liveness[mem_reg]))
+        meta_liveness[mem_reg] = list(dict.fromkeys(meta_liveness[mem_reg]))
     # if read and write entries for the same line number exist, remove the read access
     for mem_reg in meta_liveness:
         to_be_removed: Set[str] = set()

--- a/explorer/discopop_explorer/pattern_detectors/new_task_detector.py
+++ b/explorer/discopop_explorer/pattern_detectors/new_task_detector.py
@@ -194,7 +194,7 @@ def identify_simple_tasking(
         for task in tpc.registered_tasks:
             task_scopes: List[LineID] = []
             task_scopes += task.get_code_scope(ctg.pet, inclusive=True)
-            task_scopes = list(set(task_scopes))
+            task_scopes = list(dict.fromkeys(task_scopes))
             #            task_scope_file_id = task_pet_node.file_id
             task_scope_line_nums = [get_line_num(ts) for ts in task_scopes if get_file_id(ts) == parent_scope_file_id]
             filtered_task_scope_line_nums = [

--- a/explorer/discopop_explorer/pattern_detectors/simple_gpu_patterns/GPURegions.py
+++ b/explorer/discopop_explorer/pattern_detectors/simple_gpu_patterns/GPURegions.py
@@ -106,7 +106,7 @@ class GPURegionInfo(PatternInfo):
                     # found entry node
                     entry_cus.append(contained_cu_id)
         # remove duplicates
-        entry_cus = list(set(entry_cus))
+        entry_cus = list(dict.fromkeys(entry_cus))
         return entry_cus
 
     def get_exit_cus(self, pet: PEGraphX) -> Tuple[List[str], List[str]]:
@@ -123,8 +123,8 @@ class GPURegionInfo(PatternInfo):
                     contained_exit_cus.append(contained_cu_id)
                     outside_cus.append(successor_id)
         # remove duplicates
-        contained_exit_cus = list(set(contained_exit_cus))
-        outside_cus = list(set(outside_cus))
+        contained_exit_cus = list(dict.fromkeys(contained_exit_cus))
+        outside_cus = list(dict.fromkeys(outside_cus))
         return contained_exit_cus, outside_cus
 
 
@@ -298,17 +298,17 @@ class GPURegions:
                 map_to_vars: List[str] = []
                 for loop_pattern in region_loop_patterns:
                     map_to_vars += [v.name for v in loop_pattern.map_type_to + loop_pattern.map_type_tofrom]
-                map_to_vars = list(set(map_to_vars))
+                map_to_vars = list(dict.fromkeys(map_to_vars))
 
                 map_from_vars: List[str] = []
                 for loop_pattern in region_loop_patterns:
                     map_from_vars += [v.name for v in loop_pattern.map_type_from + loop_pattern.map_type_tofrom]
-                map_from_vars = list(set(map_from_vars))
+                map_from_vars = list(dict.fromkeys(map_from_vars))
 
                 map_alloc_vars: List[str] = []
                 for loop_pattern in region_loop_patterns:
                     map_alloc_vars += [v.name for v in loop_pattern.map_type_alloc]
-                map_alloc_vars = list(set(map_alloc_vars))
+                map_alloc_vars = list(dict.fromkeys(map_alloc_vars))
 
                 map_to_from_vars = [var for var in map_to_vars if var in map_from_vars]
 
@@ -316,7 +316,7 @@ class GPURegions:
                 map_alloc_vars += [
                     var for var in map_from_vars if var not in consumed_vars + map_to_vars + map_alloc_vars
                 ]
-                map_alloc_vars = list(set(map_alloc_vars))
+                map_alloc_vars = list(dict.fromkeys(map_alloc_vars))
 
                 # store results
                 self.map_type_from_by_region[tuple(region)] = [
@@ -486,7 +486,7 @@ class GPURegions:
                         for child in direct_children(pet, pet.node_at(func_node_id)):
                             device_cu_ids.append(child.id)
 
-                device_cu_ids = list(set(device_cu_ids))
+                device_cu_ids = list(dict.fromkeys(device_cu_ids))
                 current_info = GPURegionInfo(
                     self.pet,
                     contained_loop_patterns,

--- a/explorer/discopop_explorer/pattern_detectors/task_parallelism/alias_detection.py
+++ b/explorer/discopop_explorer/pattern_detectors/task_parallelism/alias_detection.py
@@ -238,7 +238,7 @@ def __add_alias_information(
                                 # second level alias found
                                 aliases += inner_statement_result
                     aliases += statement_result
-            aliases = list(set(aliases))
+            aliases = list(dict.fromkeys(aliases))
             function_information["aliases"].append(aliases)
         result_list.append(function_information)
     return result_list

--- a/explorer/discopop_explorer/pattern_detectors/task_parallelism/filter.py
+++ b/explorer/discopop_explorer/pattern_detectors/task_parallelism/filter.py
@@ -71,7 +71,7 @@ def __filter_data_sharing_clauses_suppress_shared_loop_index(
             for parent_loop in parent_loops:
                 if is_loop_index2(pet, parent_loop, var):
                     to_be_removed.append(var)
-        to_be_removed = list(set(to_be_removed))
+        to_be_removed = list(dict.fromkeys(to_be_removed))
         suggestion.shared = [v for v in suggestion.shared if v not in to_be_removed]
     return suggestions
 
@@ -105,9 +105,9 @@ def __filter_data_sharing_clauses_by_function(
         __filter_shared_clauses(suggestion, parent_function, var_def_line_dict)
 
         # remove duplicates and .addr suffix from variable names
-        suggestion.shared = list(set([v.replace(".addr", "") for v in suggestion.shared]))
-        suggestion.private = list(set([v.replace(".addr", "") for v in suggestion.private]))
-        suggestion.first_private = list(set([v.replace(".addr", "") for v in suggestion.first_private]))
+        suggestion.shared = list(dict.fromkeys([v.replace(".addr", "") for v in suggestion.shared]))
+        suggestion.private = list(dict.fromkeys([v.replace(".addr", "") for v in suggestion.private]))
+        suggestion.first_private = list(dict.fromkeys([v.replace(".addr", "") for v in suggestion.first_private]))
 
         # remove duplicates (variable occurring in different classes)
         remove_from_first_private = []
@@ -120,8 +120,8 @@ def __filter_data_sharing_clauses_by_function(
         for var in suggestion.private:
             if var in suggestion.first_private:
                 remove_from_first_private.append(var)
-        remove_from_first_private = list(set(remove_from_first_private))
-        remove_from_private = list(set(remove_from_private))
+        remove_from_first_private = list(dict.fromkeys(remove_from_first_private))
+        remove_from_private = list(dict.fromkeys(remove_from_private))
         remove_from_private = [var for var in remove_from_private if var not in remove_from_first_private]
         suggestion.private = [var for var in suggestion.private if var not in remove_from_private]
         suggestion.first_private = [var for var in suggestion.first_private if var not in remove_from_first_private]
@@ -159,7 +159,7 @@ def __filter_shared_clauses(
             pass
         if not is_valid:
             to_be_removed.append(var)
-    to_be_removed = list(set(to_be_removed))
+    to_be_removed = list(dict.fromkeys(to_be_removed))
     suggestion.shared = [v for v in suggestion.shared if not v.replace(".addr", "") in to_be_removed]
 
 
@@ -198,7 +198,7 @@ def __filter_private_clauses(
             pass
         if not is_valid:
             to_be_removed.append(var)
-    to_be_removed = list(set(to_be_removed))
+    to_be_removed = list(dict.fromkeys(to_be_removed))
     suggestion.private = [v for v in suggestion.private if not v.replace(".addr", "") in to_be_removed]
 
 
@@ -229,7 +229,7 @@ def __filter_firstprivate_clauses(
             pass
         if not is_valid:
             to_be_removed.append(var)
-    to_be_removed = list(set(to_be_removed))
+    to_be_removed = list(dict.fromkeys(to_be_removed))
     suggestion.first_private = [v for v in suggestion.first_private if not v.replace(".addr", "") in to_be_removed]
 
 
@@ -348,7 +348,7 @@ def __filter_sharing_clause(
                 # check if task suggestion cu is reachable from parent via child edges
                 if not check_reachability(pet, suggestion._node, parent_cu, [EdgeType.CHILD]):
                     to_be_removed.append(var)
-        to_be_removed = list(set(to_be_removed))
+        to_be_removed = list(dict.fromkeys(to_be_removed))
         if target_clause_list == "FP":
             suggestion.first_private = [v for v in suggestion.first_private if v not in to_be_removed]
         elif target_clause_list == "PR":
@@ -415,9 +415,9 @@ def remove_duplicate_data_sharing_clauses(suggestions: List[PatternInfo]) -> Lis
         if not type(s) == TaskParallelismInfo:
             result.append(s)
         else:
-            s.in_dep = list(set(s.in_dep))
-            s.out_dep = list(set(s.out_dep))
-            s.in_out_dep = list(set(s.in_out_dep))
+            s.in_dep = list(dict.fromkeys(s.in_dep))
+            s.out_dep = list(dict.fromkeys(s.out_dep))
+            s.in_out_dep = list(dict.fromkeys(s.in_out_dep))
             result.append(s)
     return result
 
@@ -482,7 +482,7 @@ def __filter_in_dependencies(
         if not is_valid:
             modification_found = True
             to_be_removed.append(var)
-    to_be_removed = list(set(to_be_removed))
+    to_be_removed = list(dict.fromkeys(to_be_removed))
     suggestion.in_dep = [v for v in suggestion.in_dep if not v.replace(".addr", "") in to_be_removed]
     return modification_found
 
@@ -547,7 +547,7 @@ def __filter_out_dependencies(
         if not is_valid:
             to_be_removed.append(var)
             modification_found = True
-    to_be_removed = list(set(to_be_removed))
+    to_be_removed = list(dict.fromkeys(to_be_removed))
     suggestion.out_dep = [v for v in suggestion.out_dep if not v.replace(".addr", "") in to_be_removed]
     return modification_found
 
@@ -642,11 +642,11 @@ def __filter_in_out_dependencies(
                         elif prior_out_exists and not successive_in_exists:
                             # depend in
                             suggestion.in_dep.append(var)
-                            suggestion.in_dep = list(set(suggestion.in_dep))
+                            suggestion.in_dep = list(dict.fromkeys(suggestion.in_dep))
                         elif not prior_out_exists and successive_in_exists:
                             # depend out
                             suggestion.out_dep.append(var)
-                            suggestion.out_dep = list(set(suggestion.out_dep))
+                            suggestion.out_dep = list(dict.fromkeys(suggestion.out_dep))
                 else:
                     pass
         except ValueError:
@@ -654,7 +654,7 @@ def __filter_in_out_dependencies(
         if not is_valid:
             to_be_removed.append(var)
             modification_found = True
-    to_be_removed = list(set(to_be_removed))
+    to_be_removed = list(dict.fromkeys(to_be_removed))
     suggestion.in_out_dep = [v for v in suggestion.in_out_dep if not v.replace(".addr", "") in to_be_removed]
     return modification_found
 
@@ -729,7 +729,7 @@ def filter_data_depend_clauses(
                 suggestion.in_dep.remove(v)
                 suggestion.out_dep.remove(v)
                 suggestion.in_out_dep.append(v)
-            suggestion.in_out_dep = list(set(suggestion.in_out_dep))
+            suggestion.in_out_dep = list(dict.fromkeys(suggestion.in_out_dep))
             # correct in_out vars (remove from in and out)
             for v in suggestion.in_out_dep:
                 if v in suggestion.in_dep:

--- a/explorer/discopop_explorer/pattern_detectors/task_parallelism/preprocessor.py
+++ b/explorer/discopop_explorer/pattern_detectors/task_parallelism/preprocessor.py
@@ -46,7 +46,7 @@ def cu_xml_preprocessing(cu_xml: str) -> str:
             inner_iteration = True
             remaining_recursive_call_in_parent = False
             while inner_iteration:
-                used_node_ids = list(set(used_node_ids + self_added_node_ids))
+                used_node_ids = list(dict.fromkeys(used_node_ids + self_added_node_ids))
 
                 if node.get("type") == "0":  # iterate over CU nodes
                     # find CU nodes with > 1 recursiveFunctionCalls in own code region

--- a/explorer/discopop_explorer/pattern_detectors/task_parallelism/suggesters/auxiliary.py
+++ b/explorer/discopop_explorer/pattern_detectors/task_parallelism/suggesters/auxiliary.py
@@ -43,7 +43,7 @@ def suggest_parallel_regions(pet: PEGraphX, suggestions: List[TaskParallelismInf
     for ts in task_suggestions:
         parents += get_parent_of_type(pet, ts._node, NodeType.FUNC, EdgeType.CHILD, False)
     # remove duplicates
-    parents = list(set(parents))
+    parents = list(dict.fromkeys(parents))
     # get outer-most parents of suggested tasks
     outer_parents: List[Tuple[Node, Optional[Node]]] = []
     # iterate over entries in parents.
@@ -279,14 +279,14 @@ def combine_omittable_cus(pet: PEGraphX, suggestions: List[PatternInfo]) -> List
     for key in task_suggestions_dict:
         for ts in task_suggestions_dict[key]:
             # remove duplicates
-            ts.in_dep = list(set(ts.in_dep))
-            ts.out_dep = list(set(ts.out_dep))
+            ts.in_dep = list(dict.fromkeys(ts.in_dep))
+            ts.out_dep = list(dict.fromkeys(ts.out_dep))
             # reset in_out_dep, might have changed due to combination
             if len(ts.in_dep) < len(ts.out_dep):  # just for performance
                 ts.in_out_dep = [var for var in ts.in_dep if var in ts.out_dep]
             else:
                 ts.in_out_dep = [var for var in ts.out_dep if var in ts.in_dep]
-            ts.in_out_dep = list(set(ts.in_out_dep))
+            ts.in_out_dep = list(dict.fromkeys(ts.in_out_dep))
             result.append(ts)
 
     return result

--- a/explorer/discopop_explorer/pattern_detectors/task_parallelism/suggesters/barriers.py
+++ b/explorer/discopop_explorer/pattern_detectors/task_parallelism/suggesters/barriers.py
@@ -174,7 +174,7 @@ def detect_barrier_suggestions(pet: PEGraphX, suggestions: List[PatternInfo]) ->
                 queue.append(pet.node_at(e[1]))
             for e in in_dep_edges:
                 queue.append(pet.node_at(e[0]))
-            queue = list(set(queue))
+            queue = list(dict.fromkeys(queue))
 
     return suggestions
 
@@ -508,5 +508,5 @@ def suggest_missing_barriers_for_global_vars(pet: PEGraphX, suggestions: List[Pa
                 for s, t, e in out_edges(pet, pet.node_at(succ_edge[1]).id)
                 if e.etype == EdgeType.SUCCESSOR and pet.node_at(t) != pet.node_at(succ_edge[1])
             ]
-            queue = list(set(queue + target_out_succ_edges))
+            queue = list(dict.fromkeys(queue + target_out_succ_edges))
     return suggestions

--- a/explorer/discopop_explorer/pattern_detectors/task_parallelism/suggesters/dependency_clauses.py
+++ b/explorer/discopop_explorer/pattern_detectors/task_parallelism/suggesters/dependency_clauses.py
@@ -411,11 +411,11 @@ def identify_dependencies_for_different_functions(
         if ts in out_dep_updates:
             for out_dep_var in out_dep_updates[ts]:
                 ts.out_dep.append(out_dep_var)
-            ts.out_dep = list(set(ts.out_dep))
+            ts.out_dep = list(dict.fromkeys(ts.out_dep))
         if ts in in_dep_updates:
             for in_dep_var in in_dep_updates[ts]:
                 ts.in_dep.append(in_dep_var)
-            ts.in_dep = list(set(ts.in_dep))
+            ts.in_dep = list(dict.fromkeys(ts.in_dep))
         result_suggestions.append(ts)
 
     return result_suggestions
@@ -495,7 +495,7 @@ def __get_recursive_calls_from_function(potential_children: List[Node], parent_f
         for e in child.recursive_function_calls:
             if e is not None:
                 recursive_function_calls.append(e)
-    recursive_function_calls = list(set(recursive_function_calls))
+    recursive_function_calls = list(dict.fromkeys(recursive_function_calls))
     return recursive_function_calls
 
 
@@ -637,7 +637,7 @@ def identify_dependencies_for_same_functions(
                                     int(param_entry_1[0])
                                 except ValueError:
                                     intersection.append(param_entry_1)
-                    intersection = list(set(intersection))
+                    intersection = list(dict.fromkeys(intersection))
                     # 6.2 get task suggestion corresponding to scf
                     for ts_2 in task_suggestions:
                         if ts_2 == ts_1:
@@ -684,7 +684,7 @@ def __perform_dependency_updates(
                         out_dep_var,
                     )
                 ts.out_dep.append(out_dep_var)
-            ts.out_dep = list(set(ts.out_dep))
+            ts.out_dep = list(dict.fromkeys(ts.out_dep))
         if ts in in_dep_updates:
             for in_dep_var, is_pessimistic in in_dep_updates[ts]:
                 if in_dep_var not in ts.in_dep and is_pessimistic:
@@ -695,7 +695,7 @@ def __perform_dependency_updates(
                         in_dep_var,
                     )
                 ts.in_dep.append(in_dep_var)
-            ts.in_dep = list(set(ts.in_dep))
+            ts.in_dep = list(dict.fromkeys(ts.in_dep))
         result_suggestions.append(ts)
     return result_suggestions
 
@@ -727,7 +727,7 @@ def get_alias_for_parameter_at_position(
     for cu in [pet.node_at(cuid) for cuid in [e[1] for e in out_edges(pet, function.id)]]:
         # iterate over children of CU and retrieve called functions
         called_functions = get_called_functions_recursively(pet, cu, [], called_function_cache)
-        called_functions = list(set(called_functions))
+        called_functions = list(dict.fromkeys(called_functions))
         # iterate over called functions
         for called_function in called_functions:
             # read line from source code (iterate over lines of CU to search for function call)
@@ -791,7 +791,7 @@ def check_dependence_of_task_pair(
             alias_entries_2 = []
             for alias_entry_2 in aliases[task_suggestion_2]:
                 alias_entries_2 += alias_entry_2
-            intersection = list(set([ae for ae in alias_entry if ae in alias_entries_2]))
+            intersection = list(dict.fromkeys([ae for ae in alias_entry if ae in alias_entries_2]))
             # get sink lines
             # (start and end line of task_sug_1's parent func)
             sink_lines_start = alias_entry[0][2].split(":")
@@ -818,7 +818,7 @@ def check_dependence_of_task_pair(
                         if raw_dep_entry[1] == intersecting_variable:
                             if raw_dep_entry[0] in sink_lines:
                                 dependencies.append(parameter)
-    dependencies = list(set(dependencies))
+    dependencies = list(dict.fromkeys(dependencies))
     # check if task suggestion_1 occurs prior to task_suggestion_2
     if task_suggestion_1._node.start_position().split(":")[0] == task_suggestion_2._node.start_position().split(":")[0]:
         # same file id

--- a/explorer/discopop_explorer/pattern_detectors/task_parallelism/suggesters/tasks.py
+++ b/explorer/discopop_explorer/pattern_detectors/task_parallelism/suggesters/tasks.py
@@ -334,7 +334,7 @@ def __identify_atomic_or_critical_sections(
     :param selector: True: identify atomic sections. False: identify critical sections
     """
     # remove potential duplicates from found cus
-    found_cus = list(set(found_cus))
+    found_cus = list(dict.fromkeys(found_cus))
     # get lists of combinable cus by checking successor relation
     combinations = []
     for cu in found_cus:

--- a/explorer/discopop_explorer/pattern_detectors/task_parallelism/tp_utils.py
+++ b/explorer/discopop_explorer/pattern_detectors/task_parallelism/tp_utils.py
@@ -618,7 +618,7 @@ def detect_mw_types(pet: PEGraphX, main_node: Node) -> None:
                     # remove entries which occur less than two times
                     raw_targets = [t for t in raw_targets if raw_targets.count(t) > 1]
                     # remove duplicates from list
-                    raw_targets = list(set(raw_targets))
+                    raw_targets = list(dict.fromkeys(raw_targets))
                     # if elements remaining, mark other_node as BARRIER
                     if len(raw_targets) > 0:
                         other_node.mw_type = MWType.BARRIER

--- a/explorer/discopop_explorer/utilities/ASTUtils/ASTQueries.py
+++ b/explorer/discopop_explorer/utilities/ASTUtils/ASTQueries.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import weakref
 from typing import Any, Optional
 
 import networkx as nx
@@ -155,6 +156,14 @@ class ASTQueries:
     ) -> list[str]:
         """Find nodes whose source range contains a specific location.
 
+        Descends the AST from its root node(s) instead of scanning every node:
+        a child's range is always nested within its parent's, so any subtree
+        whose range excludes *line* is skipped along with all its descendants.
+        This visits roughly O(depth-to-matches) nodes per query rather than
+        O(graph size), which matters once the AST is large enough that a full
+        scan (repeated for every query against the same static graph) would
+        dominate runtime.
+
         Args:
             graph: AST graph
             filename: Source filename
@@ -164,13 +173,48 @@ class ASTQueries:
         Returns:
             List of matching node IDs
         """
-        matching = []
-        for node_id, attrs in graph.nodes(data=True):
-            if not _file_matches(attrs.get("loc", {}).get("file"), filename):
+        matching: list[str] = []
+        visited: set[str] = set()
+        stack: list[str] = list(_get_root_node_ids(graph))
+        while stack:
+            node_id = stack.pop()
+            if node_id in visited:
                 continue
-            if ASTQueries._is_in_range(line, column, attrs.get("range", {})):
+            visited.add(node_id)
+
+            attrs = graph.nodes[node_id]
+            range_info = attrs.get("range", {})
+            if not ASTQueries._range_could_contain_line(line, range_info):
+                continue  # prune: this subtree's range excludes *line*
+
+            if _file_matches(attrs.get("loc", {}).get("file"), filename) and ASTQueries._is_in_range(
+                line, column, range_info
+            ):
                 matching.append(node_id)
+
+            stack.extend(graph.successors(node_id))
         return matching
+
+    @staticmethod
+    def _range_could_contain_line(line: int, range_info: dict[str, Any]) -> bool:
+        """Check whether a node's subtree could possibly contain *line*.
+
+        Used to prune AST subtrees during descent in :meth:`find_nodes_at_location`.
+        Nodes with incomplete range info (e.g. the TranslationUnitDecl root, which
+        Clang gives no range at all) can't be ruled out and must always be explored.
+
+        Args:
+            line: Line number to test
+            range_info: Range dict with begin_line/end_line
+
+        Returns:
+            False only when the range is fully known and definitely excludes *line*
+        """
+        begin_line = range_info.get("begin_line")
+        end_line = range_info.get("end_line")
+        if begin_line is None or end_line is None:
+            return True
+        return bool(begin_line <= line <= end_line)
 
     @staticmethod
     def _is_in_range(line: int, column: Optional[int], range_info: dict[str, Any]) -> bool:
@@ -350,6 +394,33 @@ class ASTVariableAndTypeQueries:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+# Keyed by the graph object itself (weakly) rather than id(graph): a plain
+# id()-keyed cache would risk a stale hit if a graph is garbage-collected and
+# a new, unrelated graph happens to be allocated at the same address.
+_root_node_cache: "weakref.WeakKeyDictionary[nx.DiGraph[str], list[str]]" = weakref.WeakKeyDictionary()
+
+
+def _get_root_node_ids(graph: nx.DiGraph[str]) -> list[str]:
+    """Return the graph's root node IDs (no incoming edges), cached per graph.
+
+    AST graphs are built once and then queried many times via
+    :meth:`ASTQueries.find_nodes_at_location`; computing in-degree for every
+    node is itself an O(graph size) scan, so the result is cached against the
+    graph instance to keep that cost one-time rather than per-query.
+
+    Args:
+        graph: AST graph
+
+    Returns:
+        List of node IDs with no incoming edges
+    """
+    cached = _root_node_cache.get(graph)
+    if cached is not None:
+        return cached
+    roots = [node_id for node_id in graph.nodes() if graph.in_degree(node_id) == 0]
+    _root_node_cache[graph] = roots
+    return roots
 
 
 def _file_matches(stored: Optional[str], query: str) -> bool:

--- a/explorer/discopop_explorer/utilities/PEGraphConstruction/parser.py
+++ b/explorer/discopop_explorer/utilities/PEGraphConstruction/parser.py
@@ -142,6 +142,25 @@ def __parse_dep_file(dep_fd: TextIOWrapper, output_path: str) -> Tuple[List[Depe
         with open(os.path.join(output_path, "static_dependencies.txt"), "r") as static_dep_fd:
             static_dependency_lines = static_dep_fd.readlines()
 
+    # load instruction to lineID mapping for backwards compatibility
+    instruction_to_lineID_mapping: Dict[str, str] = dict()
+    if os.path.exists(os.path.join(output_path, "instructionID_to_lineID_mapping.txt")):
+        with open(os.path.join(output_path, "instructionID_to_lineID_mapping.txt"), "r") as f:
+            for line in f.readlines():
+                line = line.replace("\n", "")
+                if line.startswith("#") or len(line) == 0:
+                    continue
+                split_line = line.split(" ")
+                instruction_id = split_line[0]
+                line_id = split_line[1]
+                if line_id.startswith("*"):
+                    continue
+                line_id_split = line_id.split(":")
+                file_id = line_id_split[0]
+                line_num = line_id_split[1]
+                column_num = line_id_split[2]
+                instruction_to_lineID_mapping[instruction_id] = str(file_id) + ":" + str(line_num)
+
     for line in dep_fd.readlines() + static_dependency_lines:
         dep_fields = line.split()
         if dep_fields[1] == "BGN" and dep_fields[2] == "loop":
@@ -161,25 +180,6 @@ def __parse_dep_file(dep_fd: TextIOWrapper, output_path: str) -> Tuple[List[Depe
             )
         if len(dep_fields) < 4 or dep_fields[1] != "NOM":
             continue
-
-        # load instruction to lineID mapping for backwards compatibility
-        instruction_to_lineID_mapping: Dict[str, str] = dict()
-        if os.path.exists(os.path.join(output_path, "instructionID_to_lineID_mapping.txt")):
-            with open(os.path.join(output_path, "instructionID_to_lineID_mapping.txt"), "r") as f:
-                for line in f.readlines():
-                    line = line.replace("\n", "")
-                    if line.startswith("#") or len(line) == 0:
-                        continue
-                    split_line = line.split(" ")
-                    instruction_id = split_line[0]
-                    line_id = split_line[1]
-                    if line_id.startswith("*"):
-                        continue
-                    line_id_split = line_id.split(":")
-                    file_id = line_id_split[0]
-                    line_num = line_id_split[1]
-                    column_num = line_id_split[2]
-                    instruction_to_lineID_mapping[instruction_id] = str(file_id) + ":" + str(line_num)
 
         sink = dep_fields[0]
         # pairwise iteration over dependencies source
@@ -322,7 +322,7 @@ def possible_reduction(line: int, src_lines: List[str]) -> bool:
     bracket_b = src_line[0:pos].rfind("]")
     assert bracket_b != -1
 
-    rex_search_res = re.search("([A-Za-z0-9_]+)\[", src_line[0 : (bracket_a + 1)])
+    rex_search_res = re.search(r"([A-Za-z0-9_]+)\[", src_line[0 : (bracket_a + 1)])
     if not rex_search_res:
         return True
 

--- a/explorer/discopop_explorer/utilities/general/generate_Data_CUInst.py
+++ b/explorer/discopop_explorer/utilities/general/generate_Data_CUInst.py
@@ -31,11 +31,11 @@ def __collect_children_ids(pet: PEGraphX, parent_id: NodeID, children_ids: List[
         # this id has already been processed. No need to go through it again
         return children_ids
     children_ids.append(parent_id)
-    children_ids = list(set(children_ids))
+    children_ids = list(dict.fromkeys(children_ids))
     # collect all of its children
     for child_node in direct_children_or_called_nodes(pet, pet.node_at(parent_id)):
         children_ids += __collect_children_ids(pet, child_node.id, children_ids)
-        children_ids = list(set(children_ids))
+        children_ids = list(dict.fromkeys(children_ids))
     return children_ids
 
 

--- a/library/discopop_library/EmpiricalAutotuning/optimization/evolutionary_combination.py
+++ b/library/discopop_library/EmpiricalAutotuning/optimization/evolutionary_combination.py
@@ -464,7 +464,7 @@ def __calculate_fitness(
     global entry_to_configuration
     logger.info("Calculating fitness...")
     logger.info("--- Removing duplicates")
-    population_wo_duplicates = list(set(population))
+    population_wo_duplicates = list(dict.fromkeys(population))
 
     compilation_successful: Dict[CHROMOSOME, bool] = dict()
 

--- a/library/discopop_library/ParallelRegionMerger/classes/TaskGraph/TaskGraph.py
+++ b/library/discopop_library/ParallelRegionMerger/classes/TaskGraph/TaskGraph.py
@@ -96,7 +96,7 @@ class TaskGraph(object):
                 if type(edge_type) == SuccessorEdge:
                     # found incoming successor edge
                     redirect_in_edges.append((in_edges[0], base_node))
-        for tpl in list(set(redirect_in_edges)):
+        for tpl in list(dict.fromkeys(redirect_in_edges)):
             self.add_successor_edge(tpl[0], enter)
             self.graph.remove_edge(tpl[0], tpl[1])
         # redirect outgoing edges
@@ -106,7 +106,7 @@ class TaskGraph(object):
                 if type(edge_type) == SuccessorEdge:
                     # found outgoing successor edge
                     redirect_out_edges.append((base_node, out_edges[1]))
-        for tpl in list(set(redirect_out_edges)):
+        for tpl in list(dict.fromkeys(redirect_out_edges)):
             self.add_successor_edge(exit, tpl[1])
             self.graph.remove_edge(tpl[0], tpl[1])
         # connect enter and exit
@@ -134,7 +134,7 @@ class TaskGraph(object):
                 if type(edge_type) == SuccessorEdge:
                     # found incoming successor edge
                     redirect_in_edges.append((in_edges[0], entry_node))
-        for tpl in list(set(redirect_in_edges)):
+        for tpl in list(dict.fromkeys(redirect_in_edges)):
             self.add_successor_edge(tpl[0], enter)
             self.graph.remove_edge(tpl[0], tpl[1])
         # redirect outgoing edges
@@ -144,7 +144,7 @@ class TaskGraph(object):
                 if type(edge_type) == SuccessorEdge:
                     # found outgoing successor edge
                     redirect_out_edges.append((exit_node, out_edges[1]))
-        for tpl in list(set(redirect_out_edges)):
+        for tpl in list(dict.fromkeys(redirect_out_edges)):
             self.add_successor_edge(exit, tpl[1])
             self.graph.remove_edge(tpl[0], tpl[1])
         # connect enter and exit

--- a/library/discopop_library/ParallelRegionMerger/inflated_parallel_region_pattern.py
+++ b/library/discopop_library/ParallelRegionMerger/inflated_parallel_region_pattern.py
@@ -588,6 +588,6 @@ def set_affected_cu_ids(
         affected_cus: List[NodeID] = par_reg.affected_cu_ids
         for contained_pattern_id in par_reg.contains_patterns:
             affected_cus += patterns_by_id[contained_pattern_id].affected_cu_ids
-        affected_cus = list(set(affected_cus))
+        affected_cus = list(dict.fromkeys(affected_cus))
         par_reg.affected_cu_ids = affected_cus
     return parallel_regions

--- a/library/discopop_library/PatchApplicator/apply.py
+++ b/library/discopop_library/PatchApplicator/apply.py
@@ -29,7 +29,7 @@ def apply_patches(
     "2: Some changes applied successfully"""
     retval = -1  # -1 -> nothing seen so far
     # get list of applicable suggestions
-    applicable_suggestions = [name for name in os.listdir(patch_generator_dir)]
+    applicable_suggestions = sorted(os.listdir(patch_generator_dir))
 
     # get already applied suggestions
     with open(applied_suggestions_file, "r") as f:
@@ -76,7 +76,7 @@ def __apply_file_patches(
     file_mapping: Dict[int, Path], suggestion_id: str, patch_generator_dir: str, arguments: PatchApplicatorArguments
 ) -> bool:
     # get a list of patches for the given suggestion
-    patch_files = os.listdir(os.path.join(patch_generator_dir, suggestion_id))
+    patch_files = sorted(os.listdir(os.path.join(patch_generator_dir, suggestion_id)))
     if arguments.verbose:
         print("\tFound patch files:", patch_files)
     encountered_error = False

--- a/library/discopop_library/PatchApplicator/rollback.py
+++ b/library/discopop_library/PatchApplicator/rollback.py
@@ -31,7 +31,7 @@ def rollback_patches(
     """
     retval = -1  # -1 -> nothing seen so far
     # get list of applicable suggestions
-    applicable_suggestions = [name for name in os.listdir(patch_generator_dir)]
+    applicable_suggestions = sorted(os.listdir(patch_generator_dir))
 
     # get already applied suggestions
     with open(applied_suggestions_file, "r") as f:
@@ -81,7 +81,7 @@ def __rollback_file_patches(
     file_mapping: Dict[int, Path], suggestion_id: str, patch_generator_dir: str, arguments: PatchApplicatorArguments
 ) -> bool:
     # get a list of patches for the given suggestion
-    patch_files = os.listdir(os.path.join(patch_generator_dir, suggestion_id))
+    patch_files = sorted(os.listdir(os.path.join(patch_generator_dir, suggestion_id)))
     if arguments.verbose:
         print("\tFound patch files:", patch_files)
 

--- a/library/discopop_library/Viewer/suggestions_view.py
+++ b/library/discopop_library/Viewer/suggestions_view.py
@@ -27,19 +27,19 @@ def print_suggestions_overview(arguments: ViewerArguments) -> None:
     suggestion_to_files_map: Dict[int, Set[int]] = dict()
     files_to_suggestions_map: Dict[int, Set[int]] = dict()
 
-    suggestion_ids = [
+    suggestion_ids = sorted(
         x
         for x in os.listdir(os.path.join(arguments.path, "patch_generator"))
         if os.path.isdir(os.path.join(arguments.path, "patch_generator", x))
-    ]
+    )
 
     for suggestion_id in suggestion_ids:
         suggestion_to_files_map[int(suggestion_id)] = set()
-        file_ids = [
+        file_ids = sorted(
             x.replace(".patch", "")
             for x in os.listdir(os.path.join(arguments.path, "patch_generator", suggestion_id))
             if os.path.isfile(os.path.join(arguments.path, "patch_generator", suggestion_id, x))
-        ]
+        )
         for file_id in file_ids:
             suggestion_to_files_map[int(suggestion_id)].add(int(file_id))
             if int(file_id) not in files_to_suggestions_map:

--- a/library/discopop_library/discopop_optimizer/PETParser/PETParser.py
+++ b/library/discopop_library/discopop_optimizer/PETParser/PETParser.py
@@ -624,7 +624,7 @@ class PETParser(object):
         self.graph.remove_node(node)
 
         retval = True
-        return retval, list(set(modified_nodes))
+        return retval, list(dict.fromkeys(modified_nodes))
 
     def __remove_non_hotspot_function_bodys(self) -> None:
         if len(self.experiment.hotspot_functions) == 0:
@@ -802,7 +802,7 @@ class PETParser(object):
                     show_dataflow=False,
                     show_mutex_edges=False,
                 )
-            nodes_in_function = list(set(nodes_in_function).union(set(added_node_ids)))
+            nodes_in_function = list(dict.fromkeys(list(nodes_in_function) + list(added_node_ids)))
 
             # re-calculate post_dominators and merge nodes
             #            post_dominators = self.__get_post_dominators(nodes_in_function)

--- a/library/discopop_library/discopop_optimizer/classes/nodes/Workload.py
+++ b/library/discopop_library/discopop_optimizer/classes/nodes/Workload.py
@@ -128,7 +128,7 @@ class Workload(GenericNode):
             # filter for called FunctionRoots
             called_function_nodes = [fr for fr in all_function_nodes if str(fr.original_cu_id) in called_cu_ids]
             # remove duplicates
-            called_function_nodes = list(set(called_function_nodes))
+            called_function_nodes = list(dict.fromkeys(called_function_nodes))
             # add costs of called function nodes to total costs
             for called_function_root in called_function_nodes:
                 total_costs = total_costs.parallelizable_plus_combine(

--- a/library/discopop_library/discopop_optimizer/optimization/evaluate_all_decision_combinations.py
+++ b/library/discopop_library/discopop_optimizer/optimization/evaluate_all_decision_combinations.py
@@ -88,7 +88,7 @@ def evaluate_all_decision_combinations(
 
         # print the sorted result for improved readability
         print("# Sorted and simplified costs of all combinations using PATH NODE IDS")
-        for combination_tuple in sorted(costs_dict.keys(), key=lambda x: costs_dict[x], reverse=True):
+        for combination_tuple in sorted(costs_dict.keys(), key=lambda x: (costs_dict[x], x), reverse=True):
             print(
                 "#",
                 combination_tuple,
@@ -100,7 +100,7 @@ def evaluate_all_decision_combinations(
 
         # print the sorted result list using parallel pattern ids for improved interpretability
         print("# Sorted and simplified costs of all combinations using PARALLEL PATTERN IDS")
-        for combination_tuple in sorted(costs_dict.keys(), key=lambda x: costs_dict[x], reverse=True):
+        for combination_tuple in sorted(costs_dict.keys(), key=lambda x: (costs_dict[x], x), reverse=True):
             new_key = []
             for node_id in combination_tuple:
                 # find pattern id
@@ -169,7 +169,9 @@ def __dump_result_to_file_using_pattern_ids(
         json.dump(dumpable_dict, fp)
 
     # dump the best option
-    for combination_tuple in sorted(costs_dict.keys(), key=lambda x: costs_dict[x]):
+    # secondary sort key on the combination tuple itself makes tie-breaking deterministic,
+    # regardless of the non-deterministic arrival order of imap_unordered() results
+    for combination_tuple in sorted(costs_dict.keys(), key=lambda x: (costs_dict[x], x)):
         new_key_2 = []
         best_configuration = None
         # collect applied suggestions

--- a/library/discopop_library/discopop_optimizer/optimization/greedy.py
+++ b/library/discopop_library/discopop_optimizer/optimization/greedy.py
@@ -115,6 +115,9 @@ def greedy_search(
                 local_results.append(local_result)
 
             # identify best option and update made_decisions
+            # sort deterministically so that ties are always resolved the same way, regardless of the
+            # non-deterministic arrival order of imap_unordered() results across process runs
+            local_results.sort(key=lambda item: (item[1], __get_dicision_list(item[0])))
             best_option: Optional[Tuple[Dict[int, List[List[int]]], int, ContextObject]] = None
             for k, e, c in local_results:
                 dbg_decisions_string = ""

--- a/library/discopop_library/discopop_optimizer/optimization/validation.py
+++ b/library/discopop_library/discopop_optimizer/optimization/validation.py
@@ -118,7 +118,7 @@ def __nested_parallelism_found(experiment: Experiment, configuration: List[int],
             called_function_nodes = [fr for fr in all_function_nodes if str(fr.original_cu_id) in called_cu_ids]
 
             # remove duplicates
-            called_function_nodes = list(set(called_function_nodes))
+            called_function_nodes = list(dict.fromkeys(called_function_nodes))
             # add to children_queue
             children_queue += [
                 fid.node_id


### PR DESCRIPTION
fix: avoid redundant WorkContext scan in dependency lookup

__get_work_contexts_by_location_and_state_id rescanned every WorkContext in the program and re-tested code-scope membership for each unique (location, state_id) pair, even though the preceding spatial-index lookup (location_to_work_contexts) had already narrowed the candidates down to exactly the contexts covering that location. Reuse that result and filter only those by state id instead.

Measured ~35% faster pattern detection on the LULESH_proxy end-to-end case, with no behavioral change (250 unit tests, 31 end-to-end tests, mypy all pass).



fix: memory requirements

fix: eliminate redundant AST/dependency parsing hotspots in discopop_explorer

__parse_dep_file re-read and re-parsed instructionID_to_lineID_mapping.txt from scratch on every matching dependency line instead of once, and ASTQueries.find_nodes_at_location linearly scanned the entire AST graph on every query. Both were the same shape of bug against static, repeatedly queried data. Profiling on LULESH showed this dropped total explorer runtime from 400.6s to 111.9s.

find_nodes_at_location now descends from the AST's root node(s) and prunes subtrees whose range can't contain the query location, since child ranges are always nested within their parent's.



fix: guard against cyclic parent_context chains causing unbounded memory growth

Context.get_ancestor_contexts() and get_closest_function_ancestor() walked parent_context pointers with no cycle detection. On some runs, non-deterministic ordering during branch-context construction produces a cyclic parent_context chain between two Context objects; walking it then appends to a list forever, growing memory without bound (observed up to ~19GB) until the process is killed. Both methods now track visited contexts and break out (with a logged warning) if a chain is revisited.

ContextTaskGraph.__construct_from_task_graph had the same class of bug in its successor-context BFS: it only checked membership against the current queue contents ("nd not in queue") rather than a persistent visited set, so a cycle in the underlying task/control-flow graph (e.g. a real program loop) caused nodes to be rediscovered and re-enqueued indefinitely. Replaced with a persistent visited_tg_nodes set so each node is processed at most once.



fix: non-determinism

fix: make list/set ordering deterministic across pattern detectors and tooling

Replace list(set(...)) dedup with list(dict.fromkeys(...)) at ~30 call sites (mostly variable/dependency lists feeding OpenMP clause text) and sort os.listdir() results before use in the suggestion viewer and patch applicator/rollback tooling. set() iteration order over strings and custom objects depends on hash randomization / object identity, which varies across process runs even for identical input; dict.fromkeys() dedups identically while preserving deterministic first-seen order.



fix: deterministic tie-break for optimizer best-configuration selection

evaluate_all_decision_combinations() and greedy_search() picked the best configuration from multiprocessing.Pool.imap_unordered() results without a deterministic tie-break. On equal-cost configurations, which one got selected (and written to exhaustive_pattern_id.txt / evolutionary_pattern_id.txt) depended on worker completion order, which varies across process runs. Add a stable secondary sort key (the configuration itself) so ties resolve the same way regardless of arrival order.



fix: derive branch/merge regions from dominance instead of local degree

__add_branching_nodes used a purely local heuristic (any node with >1 successors becomes a branch-start, any node with >1 predecessors becomes a merge) with no guarantee the resulting Start/EndBranchParent markers are properly nested. When independent decision points converge on the same point (e.g. a loop's own exit and an internal break both reaching the code that follows the loop), this produced improperly nested regions, which downstream context assignment resolves via last-write-wins depending on graph traversal order - the true root cause of the non-deterministic pattern-detection results already partially addressed by the ordering fixes in 72aa90c7/e80f29fe.

Replace it with a per-function dominance/post-dominance analysis: each branch point is paired with its immediate post-dominator (the unique point all of its arms are guaranteed to reconverge at), processed innermost-first so nesting composes correctly regardless of how many decision points feed the same merge. A fallback pass reproduces the old unconditional wrapping for any residual case the dominance-based pass can't resolve (e.g. genuinely independent sibling branches sharing one merge), so the existing structural invariant always holds.



fix: avoid forking a worker pool for zero function-metadata work

calculateFunctionMetadata unconditionally created a multiprocessing.Pool (os.cpu_count() workers) right after PET graph construction, even when there were no functions left to process after hotspot filtering. With hotspot detection returning no results (common when hotspot data isn't available), this forked 8 workers to do literally nothing, immediately after the parent process built its full in-memory graph - occasionally spiking memory by 14-18GB+ via copy-on-write page duplication, with severity depending on non-deterministic kernel/scheduling timing.

Confirmed via 20 repeated LULESH runs: 4/20 (20%) hit the blowup before this fix; 10/10 clean afterwards, with peak RSS identical across every run. Skip Pool creation entirely when there is no work to hand it.



perf: compute per-function reachability with one memoized bottom-up pass

calculate_reachability_pairs copied and successor-filtered the entire program graph for every single function, then ran an independent DFS traversal per CU node in that function - O(N) DFS calls each up to O(N), i.e. O(N^2) time for a function with N CUs. For a large, straight-line-heavy function this is a real cost multiplied across however many functions get processed via the multiprocessing pool.

Replace it with one pass computed on a subgraph scoped to just this function's own CUs: reachable(n) = {n} | union(reachable(succ) for succ in successors(n)), processed in reverse topological order of the SCC condensation (so cycles/loops are handled correctly - all members of one SCC share a single reachable set) so each node's result is built once from its already-computed successors instead of being re-derived from scratch. Verified byte-for-byte identical output against the old implementation on DAGs, cyclic graphs, and random graphs; ~56x faster on a 3000-node worst-case linear chain (10.2s -> 0.18s).



chore: logging

perf: memoize state-id assignment to avoid exponential context re-traversal

`__assign_state_ids`/`recursive_assignment` walked each context both via its parent's `contained_contexts` set and via `successor` chains, re-exploring the same `(context, callstate)` states an exponential number of times. On the real rodinia hotspot data this intermittently blew up to ~1.5 billion recursive calls (~4.5 min for the phase), depending on the non-deterministically-built context structure, while benign structures finished in ~0.06s.

Memoize `recursive_assignment` per state-id search on `(id(ctx), incoming callstate)`. The function is deterministic in that pair and its only side effect (appending the state_id to matching contexts) is fully determined by it, so a cached pair would only ever re-append the identical state_id to the identical contexts. Memoization thus preserves the exact set of (context -> state_id) assignments (verified: memo vs non-memo produce byte-identical per-context state_id sets) while collapsing the traversal to the number of distinct reachable states. Measured on hotspot: ~12k-66k calls and <=0.02s regardless of structure.

Also hoist the `entry_points` computation out of the per-state loop and replace `copy.deepcopy(smd_entry)` with a shallow `list(...)` (entries are immutable strings).



chore: code simplification

perf: run function-metadata computation serially to avoid graph-duplication OOM

calculateFunctionMetadata fanned out over a multiprocessing.Pool that passed the whole PEGraphX to every worker via initargs. Under fork, each worker's graph traversal dirties copy-on-write pages of the shared graph, so peak memory scaled linearly with the (uncapped, = os.cpu_count()) worker count - roughly one graph copy per core. Measured on LULESH: 146MiB -> 1.1GiB peak at 8 workers, and multi-GB OOM kills on many-core machines.

The metadata computation is cheap (the per-function reachability pass is memoized and effectively O(N)), so the parallelism is not worth the OOM risk. Run it serially in-process: the graph is never duplicated (mprof peak drops from 1111MiB to 147MiB on LULESH), and the previous zero-work early-exit is subsumed by the empty loop.

Detection-relevant output is unchanged: reachability_pairs and parent_function_id are byte-identical to the pool path (0 mismatches on hotspot and LULESH). One intended difference: the pool discarded each worker's children_cu_ids mutation (done on the pickled copy, never marshalled back), so real nodes kept children_cu_ids=None; the serial path operates on the real objects, correctly populating it - strictly safer for the downstream readers that cast it to List assuming non-None.